### PR TITLE
feat/도서검색 api

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/book/client/AladinApiClient.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/client/AladinApiClient.java
@@ -1,0 +1,39 @@
+package com.shelfeed.backend.domain.book.client;
+
+import com.shelfeed.backend.domain.book.dto.external.AladinSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class AladinApiClient {
+
+    private static final String ALADIN_SEARCH_URL = "http://www.aladin.co.kr/ttb/api/ItemSearch.aspx";
+
+    private final RestTemplate restTemplate;
+
+    @Value("${aladin.api.ttbkey}")
+    private String ttbKey;
+
+    @Value("${aladin.api.version}")
+    private String version;
+
+    public AladinSearchResponse searchBooks(String query, int page, int maxResults) {
+        String url = UriComponentsBuilder.fromHttpUrl(ALADIN_SEARCH_URL)
+                .queryParam("TTBKey", ttbKey)
+                .queryParam("Query", query)
+                .queryParam("QueryType", "Keyword")
+                .queryParam("MaxResults", maxResults)
+                .queryParam("start", page)
+                .queryParam("SearchTarget", "Book")
+                .queryParam("output", "js")
+                .queryParam("Version", version)
+                .build()
+                .toUriString();
+
+        return restTemplate.getForObject(url, AladinSearchResponse.class);
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
@@ -1,0 +1,30 @@
+package com.shelfeed.backend.domain.book.controller;
+
+import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
+import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
+import com.shelfeed.backend.domain.book.service.BookService;
+import com.shelfeed.backend.global.common.response.ApiResponse;
+import com.shelfeed.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/books")
+@RequiredArgsConstructor
+public class BookController {
+
+    private final BookService bookService;
+
+    // 도서 검색  GET /api/v1/books/search
+    @GetMapping("/search")
+    public ApiResponse<BookSearchListResponse> searchBooks(
+            @ModelAttribute BookSearchRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberUserId = userDetails.getMember().getMemberUserId();
+        return ApiResponse.success(200, bookService.searchBooks(request, memberUserId));
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/dto/external/AladinBookItem.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/dto/external/AladinBookItem.java
@@ -1,0 +1,24 @@
+package com.shelfeed.backend.domain.book.dto.external;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AladinBookItem {
+    private String title;
+    private String author;
+    private String publisher;
+    private String pubDate;
+    private String isbn13;
+    private long itemId;
+    private String cover;
+    private String description;
+    private SubInfo subInfo;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class SubInfo {
+        private Integer itemPage;
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/dto/external/AladinSearchResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/dto/external/AladinSearchResponse.java
@@ -1,0 +1,15 @@
+package com.shelfeed.backend.domain.book.dto.external;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AladinSearchResponse {
+    private int totalResults;
+    private int startIndex;
+    private int itemsPerPage;
+    private List<AladinBookItem> item;
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/dto/request/BookSearchRequest.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/dto/request/BookSearchRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class BookSearchRequest { //API 명세서 속 쿼리 파라미터 용
     private String query;    // 검색어 (필수)
-    private Long cursor;     // 페이지네이션 커서 (선택)
+    private String cursor;   // 페이지네이션 커서 base64 인코딩 (선택)
     private int limit = 20;  // 기본 20, 최대 50
 
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/dto/respond/BookSearchListResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/dto/respond/BookSearchListResponse.java
@@ -9,20 +9,7 @@ import java.util.List;
 @Builder
 public class BookSearchListResponse {
     private List<BookSummaryResponse> content;
-    private Long nextCursor;
+    private String nextCursor;  // base64 인코딩된 {"page":N}
     private boolean hasNext;
     private int size;
-
-    public static BookSearchListResponse of(List<BookSummaryResponse>content, int limit){
-        boolean hasNext = content.size()>limit;
-        List<BookSummaryResponse> result = hasNext ? content.subList(0, limit) : content;
-        Long nextCursor = hasNext ? result.get(result.size() -1).getBookId() : null;
-
-    return BookSearchListResponse.builder()
-            .content(result)
-            .nextCursor(nextCursor)
-            .hasNext(hasNext)
-            .size(result.size())
-            .build();
-    }
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/repository/BookRepository.java
@@ -1,15 +1,20 @@
 package com.shelfeed.backend.domain.book.repository;
 
 import com.shelfeed.backend.domain.book.entity.Book;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     Optional<Book> findByIsbn13(String isbn13); //isbn바코드 조회 확인
+
+    // isbn13 목록으로 배치 조회 (검색 결과 중 DB에 이미 있는 책 확인용)
+    List<Book> findByIsbn13In(List<String> isbn13List);
     //도서의 평균 평점 쿼리
     @Query("""
 SELECT AVG(r.rating) FROM Review r WHERE r.book.bookId = :bookId AND r.isDeleted = false

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -1,0 +1,116 @@
+package com.shelfeed.backend.domain.book.service;
+
+import com.shelfeed.backend.domain.book.client.AladinApiClient;
+import com.shelfeed.backend.domain.book.dto.external.AladinBookItem;
+import com.shelfeed.backend.domain.book.dto.external.AladinSearchResponse;
+import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
+import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
+import com.shelfeed.backend.domain.book.dto.respond.BookSummaryResponse;
+import com.shelfeed.backend.domain.book.entity.Book;
+import com.shelfeed.backend.domain.book.repository.BookRepository;
+import com.shelfeed.backend.domain.library.repository.LibraryRepository;
+import com.shelfeed.backend.domain.member.entity.Member;
+import com.shelfeed.backend.domain.member.repository.MemberRepository;
+import com.shelfeed.backend.global.common.exception.BusinessException;
+import com.shelfeed.backend.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookService {
+
+    private final BookRepository bookRepository;
+    private final LibraryRepository libraryRepository;
+    private final MemberRepository memberRepository;
+    private final AladinApiClient aladinApiClient;
+
+    public BookSearchListResponse searchBooks(BookSearchRequest request, Long memberUserId) {
+        int limit = Math.min(request.getLimit(), 50);
+        int page = decodeCursorToPage(request.getCursor());
+
+        Member member = memberRepository.findByMemberUserId(memberUserId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        AladinSearchResponse aladinResponse = aladinApiClient.searchBooks(request.getQuery(), page, limit);
+        List<AladinBookItem> items = aladinResponse.getItem() != null ? aladinResponse.getItem() : List.of();
+
+        // 유효한 isbn13 목록 추출
+        List<String> isbn13List = items.stream()
+                .map(AladinBookItem::getIsbn13)
+                .filter(isbn -> isbn != null && !isbn.isBlank())
+                .collect(Collectors.toList());
+
+        // DB에 이미 있는 책 배치 조회 (isbn13 → bookId 매핑)
+        Map<String, Long> isbn13ToBookId = bookRepository.findByIsbn13In(isbn13List).stream()
+                .collect(Collectors.toMap(Book::getIsbn13, Book::getBookId));
+
+        // 사용자 서재에 있는 isbn13 배치 조회
+        Set<String> libraryIsbn13Set = libraryRepository.findIsbn13InLibrary(member, isbn13List);
+
+        List<BookSummaryResponse> responses = items.stream()
+                .filter(item -> item.getIsbn13() != null && !item.getIsbn13().isBlank())
+                .map(item -> {
+                    Long bookId = isbn13ToBookId.get(item.getIsbn13());
+                    boolean inMyLibrary = libraryIsbn13Set.contains(item.getIsbn13());
+
+                    String author = item.getAuthor() != null
+                            ? item.getAuthor().replaceAll("\\s*\\(.*?\\)", "").trim()
+                            : null;
+                    LocalDate publishedDate = null;
+                    if (item.getPubDate() != null && !item.getPubDate().isBlank()) {
+                        try {
+                            publishedDate = LocalDate.parse(item.getPubDate());
+                        } catch (Exception ignored) {}
+                    }
+
+                    return BookSummaryResponse.builder()
+                            .bookId(bookId)
+                            .isbn13(item.getIsbn13())
+                            .title(item.getTitle())
+                            .author(author)
+                            .publisher(item.getPublisher())
+                            .coverImageUrl(item.getCover())
+                            .publishedDate(publishedDate)
+                            .inMyLibrary(inMyLibrary)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        boolean hasNext = aladinResponse.getTotalResults() > (long) page * limit;
+        String nextCursor = hasNext ? encodeCursorFromPage(page + 1) : null;
+
+        return BookSearchListResponse.builder()
+                .content(responses)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .size(responses.size())
+                .build();
+    }
+
+    private int decodeCursorToPage(String cursor) {
+        if (cursor == null || cursor.isBlank()) return 1;
+        try {
+            String json = new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
+            String pageStr = json.replaceAll(".*\"page\"\\s*:\\s*(\\d+).*", "$1");
+            return Integer.parseInt(pageStr);
+        } catch (Exception e) {
+            return 1;
+        }
+    }
+
+    private String encodeCursorFromPage(int page) {
+        String json = "{\"page\":" + page + "}";
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface LibraryRepository extends JpaRepository<LibraryBook,Long> {
     //중복 확인
@@ -25,6 +26,10 @@ public interface LibraryRepository extends JpaRepository<LibraryBook,Long> {
 
     //유저 본인의 서재인가 확인
     Optional<LibraryBook> findByLibraryBookIdAndMemberId(Long libraryBookId, Member member);
+
+    // 도서 검색 결과 중 서재에 담긴 isbn13 배치 조회
+    @Query("SELECT lb.book.isbn13 FROM LibraryBook lb WHERE lb.memberId = :member AND lb.book.isbn13 IN :isbn13List")
+    Set<String> findIsbn13InLibrary(@Param("member") Member member, @Param("isbn13List") List<String> isbn13List);
 
     //타 유저 서재 목록
     @Query("SELECT lb FROM LibraryBook lb WHERE lb.memberId = :member " +

--- a/src/main/java/com/shelfeed/backend/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/shelfeed/backend/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.shelfeed.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,4 +20,4 @@ oauth2:
 
 aladin:
   api:
-    ttbkey: ${ALADIN_API_KEY}
+    ttbkey: ttbkeitkeit2123001


### PR DESCRIPTION
1. 요청 진입 - BookController

  GET /api/v1/books/search?query=한강&limit=20

  @ModelAttribute BookSearchRequest가 쿼리 파라미터를 DTO에 자동으로 바인딩합니다.
  @AuthenticationPrincipal로 JWT에서 인증된 사용자 정보를 꺼냅니다.

  ---
  2. 커서 디코딩 - decodeCursorToPage()

  ┌─────────────┬──────────────────┬───────────────────────────────────────┐
  │    상황     │    cursor 값     │                 결과                  │
  ├─────────────┼──────────────────┼───────────────────────────────────────┤
  │ 첫 요청     │ null             │ page = 1                              │
  ├─────────────┼──────────────────┼───────────────────────────────────────┤
  │ 다음 페이지 │ eyJwYWdlIjoyfQ== │ base64 디코딩 → {"page":2} → page = 2 │
  └─────────────┴──────────────────┴───────────────────────────────────────┘

  ---
  3. 알라딘 API 호출 - AladinApiClient

  http://www.aladin.co.kr/ttb/api/ItemSearch.aspx
    ?TTBKey=ttbkeitkeit2123001
    &Query=한강
    &QueryType=Keyword     ← 제목+저자+출판사 통합검색
    &MaxResults=20
    &start=1              ← 페이지 번호
    &SearchTarget=Book
    &output=js            ← JSON 형식 응답 요청
    &Version=20131101

  응답은 AladinSearchResponse로 역직렬화됩니다:
  {
    "totalResults": 87,
    "item": [
      { "title": "채식주의자", "author": "한강 (지은이)", "isbn13": "9788936434267", ... },
      ...
    ]
  }

  ---
  4. DB 배치 조회 2번

  ① isbn13 목록으로 이미 DB에 있는 책 조회
  SELECT * FROM books WHERE isbn13 IN ('9788936434267', '9788954681230', ...)
  → 결과를 Map<isbn13, bookId> 로 변환해서 나중에 O(1) 탐색

  ② 사용자 서재에서 isbn13 목록 조회
  SELECT lb.book.isbn13 FROM library_books lb
  WHERE lb.member_id = ? AND lb.book.isbn13 IN ('9788936434267', ...)
  → 결과를 Set<isbn13> 으로 변환해서 O(1) 탐색

  ---
  5. 응답 매핑

  알라딘 결과 20개를 순회하면서:

  책 A (isbn13: 9788936434267)
    ├── isbn13ToBookId.get("9788936434267") → bookId: 3  (DB에 있음)
    └── libraryIsbn13Set.contains("9788936434267") → true (서재에 있음)

  책 B (isbn13: 9791234567890)
    ├── isbn13ToBookId.get("9791234567890") → null  (DB에 없음)
    └── libraryIsbn13Set.contains("9791234567890") → false (서재에 없음)

  저자명 정제도 여기서 처리합니다:
  "한강 (지은이)" → replaceAll("\\s*\\(.*?\\)", "") → "한강"
  "Stephen King (지은이), 정영목 (옮긴이)" → "Stephen King, 정영목"

  ---
  6. 다음 커서 생성

  // 알라딘 totalResults=87, 현재 page=1, limit=20
  // 87 > 1*20 → hasNext = true
  // nextCursor = base64({"page":2}) = "eyJwYWdlIjoyfQ=="

  프론트에서 다음 페이지 요청 시 이 cursor 값을 그대로 넘기면 2페이지를 조회합니다.

  ---
  최종 응답

  {
    "status": "SUCCESS",
    "code": 200,
    "data": {
      "content": [
        { "bookId": 3,    "isbn13": "9788936434267", "title": "채식주의자", "inMyLibrary": true },
        { "bookId": null, "isbn13": "9791234567890", "title": "작별하지 않는다", "inMyLibrary": false }
      ],
      "nextCursor": "eyJwYWdlIjoyfQ==",
      "hasNext": true,
      "size": 20
    }
  }  


DB 쓰기: 0번 / 외부 API 호출: 1번 / DB 조회: 2번 (총 3번의 I/O)