### PR TITLE
feat bookApi + 외부 API 연동 확인 

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/book/client/AladinApiClient.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/client/AladinApiClient.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
+
 @Component//동기
 @RequiredArgsConstructor
 public class AladinApiClient {
@@ -23,7 +25,7 @@ public class AladinApiClient {
 
     //도서검색
     public AladinSearchResponse search(String query, int start, int maxResults){
-        String url = UriComponentsBuilder.fromHttpUrl(SEARCH_URL) //uri 변경
+        URI uri = UriComponentsBuilder.fromHttpUrl(SEARCH_URL) //uri 변경
                 .queryParam("ttbkey", ttbKey) //인증키
                 .queryParam("Query", query) //검색어
                 .queryParam("QueryType", "Keyword") //키워드
@@ -32,21 +34,24 @@ public class AladinApiClient {
                 .queryParam("SearchTarget", "Book")// 단행본 한정
                 .queryParam("output", "js")// JSON요청
                 .queryParam("Version", version) //사용할 외부 API 버전
-                .toUriString();
-        return restTemplate.getForObject(url, AladinSearchResponse.class);
+                .encode() // 한 번만 인코딩 (이중 인코딩 방지)
+                .build()
+                .toUri();
+        return restTemplate.getForObject(uri, AladinSearchResponse.class);
     }
     // ISBN으로 도서 조회
     public AladinSearchResponse lookupByIsbn(String isbn13) {
-        String url = UriComponentsBuilder.fromHttpUrl(LOOKUP_URL) //uri 변경
+        URI uri = UriComponentsBuilder.fromHttpUrl(LOOKUP_URL) //uri 변경
                 .queryParam("ttbkey", ttbKey) //인증키
                 .queryParam("itemIdType", "ISBN13")// 조회할 식별자 종류
                 .queryParam("ItemId", isbn13)//실제 식별자 값
                 .queryParam("output", "js")// JSON요청
                 .queryParam("Version", version) //사용할 외부 API 버전
                 .queryParam("OptResult", "packing")// 부가정보
-                .toUriString();
-
-        return restTemplate.getForObject(url, AladinSearchResponse.class);
+                .encode() // 한 번만 인코딩 (이중 인코딩 방지)
+                .build()
+                .toUri();
+        return restTemplate.getForObject(uri, AladinSearchResponse.class);
     }
 
 

--- a/src/main/java/com/shelfeed/backend/domain/book/client/AladinApiClient.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/client/AladinApiClient.java
@@ -1,0 +1,54 @@
+package com.shelfeed.backend.domain.book.client;
+
+import com.shelfeed.backend.domain.book.client.dto.AladinSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component//동기
+@RequiredArgsConstructor
+public class AladinApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${aladin.api.ttbkey}")
+    private String ttbKey;
+    @Value("${aladin.api.version}")
+    private String version;
+
+    private static final String SEARCH_URL = "https://www.aladin.co.kr/ttb/api/ItemSearch.aspx";
+    private static final String LOOKUP_URL  = "https://www.aladin.co.kr/ttb/api/ItemLookUp.aspx";
+
+    //도서검색
+    public AladinSearchResponse search(String query, int start, int maxResults){
+        String url = UriComponentsBuilder.fromHttpUrl(SEARCH_URL) //uri 변경
+                .queryParam("ttbkey", ttbKey) //인증키
+                .queryParam("Query", query) //검색어
+                .queryParam("QueryType", "Keyword") //키워드
+                .queryParam("MaxResults", maxResults) // 최대 검색 결과 수
+                .queryParam("start", start)// 시작페이지
+                .queryParam("SearchTarget", "Book")// 단행본 한정
+                .queryParam("output", "js")// JSON요청
+                .queryParam("Version", version) //사용할 외부 API 버전
+                .toUriString();
+        return restTemplate.getForObject(url, AladinSearchResponse.class);
+    }
+    // ISBN으로 도서 조회
+    public AladinSearchResponse lookupByIsbn(String isbn13) {
+        String url = UriComponentsBuilder.fromHttpUrl(LOOKUP_URL) //uri 변경
+                .queryParam("ttbkey", ttbKey) //인증키
+                .queryParam("itemIdType", "ISBN13")// 조회할 식별자 종류
+                .queryParam("ItemId", isbn13)//실제 식별자 값
+                .queryParam("output", "js")// JSON요청
+                .queryParam("Version", version) //사용할 외부 API 버전
+                .queryParam("OptResult", "packing")// 부가정보
+                .toUriString();
+
+        return restTemplate.getForObject(url, AladinSearchResponse.class);
+    }
+
+
+
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinItem.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinItem.java
@@ -3,8 +3,10 @@ package com.shelfeed.backend.domain.book.client.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AladinItem {
     private String isbn13;
@@ -21,6 +23,7 @@ public class AladinItem {
     private SubInfo subInfo;
 
     @Getter
+    @Setter
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class SubInfo{
         private Integer itemPage;

--- a/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinItem.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinItem.java
@@ -1,0 +1,29 @@
+package com.shelfeed.backend.domain.book.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AladinItem {
+    private String isbn13;
+    private String title;
+    private String author;
+    private String publisher;
+    private String cover;
+    private String description;
+    private String pubDate;
+    private Long itemId;
+    private String categoryName;
+
+    @JsonProperty("subInfo")
+    private SubInfo subInfo;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class SubInfo{
+        private Integer itemPage;
+    }
+
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinSearchResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinSearchResponse.java
@@ -3,10 +3,12 @@ package com.shelfeed.backend.domain.book.client.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)//역직렬화(JSON->JAVA 객체)
 public class AladinSearchResponse {
     @JsonProperty("item")

--- a/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinSearchResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/client/dto/AladinSearchResponse.java
@@ -1,0 +1,14 @@
+package com.shelfeed.backend.domain.book.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)//역직렬화(JSON->JAVA 객체)
+public class AladinSearchResponse {
+    @JsonProperty("item")
+    private List<AladinItem> items;
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
@@ -1,0 +1,29 @@
+package com.shelfeed.backend.domain.book.controller;
+
+import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
+import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
+import com.shelfeed.backend.domain.book.service.BookService;
+import com.shelfeed.backend.global.common.response.ApiResponse;
+import com.shelfeed.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/books")
+@RequiredArgsConstructor
+public class BookController {
+    private final BookService bookService;
+
+    // 1. 도서 검색  GET /api/v1/books/search
+    @GetMapping("/search")
+    public ApiResponse<BookSearchListResponse> searchBooks(
+            @ModelAttribute BookSearchRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+        Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId():null;
+        return ApiResponse.success(200, bookService.searchBooks(request,memberUserId));
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
@@ -33,4 +33,13 @@ public class BookController {
         Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId() : null;
         return ApiResponse.success(200, bookService.getBook(bookId,memberUserId));
     }
+
+    // 3. ISBN 조회  GET /api/v1/books/isbn/{isbn13}
+    @GetMapping("/isbn/{isbn13}")
+    public ApiResponse<BookDetailResponse> getBookByIsbn(
+            @PathVariable String isbn13,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId() : null;
+        return ApiResponse.success(200, bookService.getBookByIsbn(isbn13, memberUserId));
+    }
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
@@ -1,16 +1,14 @@
 package com.shelfeed.backend.domain.book.controller;
 
 import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
+import com.shelfeed.backend.domain.book.dto.respond.BookDetailResponse;
 import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
 import com.shelfeed.backend.domain.book.service.BookService;
 import com.shelfeed.backend.global.common.response.ApiResponse;
 import com.shelfeed.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/books")
@@ -25,5 +23,14 @@ public class BookController {
             @AuthenticationPrincipal CustomUserDetails userDetails){
         Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId():null;
         return ApiResponse.success(200, bookService.searchBooks(request,memberUserId));
+    }
+
+    // 2. 도서 상세 조회  GET /api/v1/books/{bookId}
+    @GetMapping("/{bookId}")
+    public ApiResponse<BookDetailResponse> getBook(
+            @PathVariable Long bookId,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+        Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId() : null;
+        return ApiResponse.success(200, bookService.getBook(bookId,memberUserId));
     }
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/controller/BookController.java
@@ -1,7 +1,9 @@
 package com.shelfeed.backend.domain.book.controller;
 
+import com.shelfeed.backend.domain.book.dto.request.BookReviewSearchRequest;
 import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
 import com.shelfeed.backend.domain.book.dto.respond.BookDetailResponse;
+import com.shelfeed.backend.domain.book.dto.respond.BookReviewListResponse;
 import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
 import com.shelfeed.backend.domain.book.service.BookService;
 import com.shelfeed.backend.global.common.response.ApiResponse;
@@ -41,5 +43,15 @@ public class BookController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId() : null;
         return ApiResponse.success(200, bookService.getBookByIsbn(isbn13, memberUserId));
+    }
+
+    // 4. 도서별 감상 목록  GET /api/v1/books/{bookId}/reviews
+    @GetMapping("/{bookId}/reviews")
+    public ApiResponse<BookReviewListResponse> getBookReviews(
+            @PathVariable Long bookId,
+            @ModelAttribute BookReviewSearchRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId() : null;
+        return ApiResponse.success(200, bookService.getBookReviews(bookId, request, memberUserId));
     }
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/dto/request/BookReviewSearchRequest.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/dto/request/BookReviewSearchRequest.java
@@ -1,10 +1,18 @@
 package com.shelfeed.backend.domain.book.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class BookReviewSearchRequest { //API 명세서 속 쿼리 파라미터 용
+    @Schema(defaultValue = "latest", allowableValues = {"latest", "popular", "rating_high", "rating_low"})
     private String sort = "latest";  // latest, popular, rating_high, rating_low
+
+    @Schema(description = "페이지네이션 커서 (선택)", nullable = true)
     private Long cursor;    // 페이지네이션 커서 (선택)
+
+    @Schema(defaultValue = "20", minimum = "1", maximum = "50")
     private int limit = 20; // 기본 20, 최대 50
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/dto/request/BookSearchRequest.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/dto/request/BookSearchRequest.java
@@ -1,11 +1,15 @@
 package com.shelfeed.backend.domain.book.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class BookSearchRequest { //API 명세서 속 쿼리 파라미터 용
     private String query;    // 검색어 (필수)
-    private Long cursor;     // 페이지네이션 커서 (선택)
+
+    @Schema(defaultValue = "20", minimum = "1", maximum = "50")
     private int limit = 20;  // 기본 20, 최대 50
 
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/entity/Book.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/entity/Book.java
@@ -46,4 +46,20 @@ public class Book extends BaseTimeEntity {
     @Column(length = 100)
     private String category;
 
+    public static Book create(String isbn13, String title, String author, String publisher,
+                              String coverImageUrl, String description, Integer totalPages,
+                              LocalDate publishedDate, String aladinItemId, String category) {
+        Book book = new Book();
+        book.isbn13 = isbn13;
+        book.title = title;
+        book.author = author;
+        book.publisher = publisher;
+        book.coverImageUrl = coverImageUrl;
+        book.description = description;
+        book.totalPages = totalPages;
+        book.publishedDate = publishedDate;
+        book.aladinItemId = aladinItemId;
+        book.category = category;
+        return book;
+    }
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -1,0 +1,99 @@
+package com.shelfeed.backend.domain.book.service;
+
+import com.shelfeed.backend.domain.book.client.AladinApiClient;
+import com.shelfeed.backend.domain.book.client.dto.AladinItem;
+import com.shelfeed.backend.domain.book.client.dto.AladinSearchResponse;
+import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
+import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
+import com.shelfeed.backend.domain.book.dto.respond.BookSummaryResponse;
+import com.shelfeed.backend.domain.book.entity.Book;
+import com.shelfeed.backend.domain.book.repository.BookRepository;
+import com.shelfeed.backend.domain.library.repository.LibraryRepository;
+import com.shelfeed.backend.domain.member.entity.Member;
+import com.shelfeed.backend.domain.member.repository.MemberRepository;
+import com.shelfeed.backend.domain.review.repository.ReviewLikeRepository;
+import com.shelfeed.backend.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookService {
+
+    private final BookRepository bookRepository;
+    private final MemberRepository memberRepository;
+    private final LibraryRepository libraryRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
+    private final AladinApiClient aladinApiClient;
+
+
+    // 1. 도서 검색
+    @Transactional
+    public BookSearchListResponse searchBooks(BookSearchRequest request, Long memberUserId) {
+        AladinSearchResponse response = aladinApiClient.search(request.getQuery(), 1 , request.getLimit() +1); //무한스크롤을 위해 +1 개 더 조회
+    if (response == null || response.getItems() == null) {
+        return BookSearchListResponse.of(List.of(), request.getLimit());// 내용없으면 빈 리스트
+    }
+
+    List<Book> books = response.getItems().stream().map(this::findOrCreateBook).toList();//getItems들을 findOrCreateBook 넣어라
+    Member member= memberUserId != null ? getMemberOrNull(memberUserId) : null;//멤버 없으면 null 있으면 사용
+
+    //책이 유저의 서재에 담겨 있는가
+    List<BookSummaryResponse> content = books.stream().map(book -> { //각 책들을
+        boolean inMyLibrary = member != null && libraryRepository.existsByMemberIdAndBook_BookId(member, book.getBookId());//로그인이 되어있고 회원이 저장한 책이라면
+        return BookSummaryResponse.of(book,inMyLibrary);
+    }).toList();
+
+    return BookSearchListResponse.of(content, request.getLimit());
+    }
+
+
+
+
+
+
+
+    // 2. 도서 상세 조회
+    // 3. ISBN 조회
+    // 4. 도서별 감상 목록
+
+
+    // 알라딘 아이템 → DB Book (없으면 저장)
+    private Book findOrCreateBook(AladinItem item) {
+        return bookRepository.findByIsbn13(item.getIsbn13())
+                .orElseGet(() -> {
+                    LocalDate pubDate = null;
+                    try {
+                        pubDate = LocalDate.parse(item.getPubDate());
+                    } catch (Exception ignored) {} //날짜형식이 달라도 에러 안생기게
+                    //페이지 있으면 넣고 아니면 말고
+                    Integer totalPages = item.getSubInfo() != null ? item.getSubInfo().getItemPage() : null;
+
+                    Book book = Book.create(
+                            item.getIsbn13(),
+                            item.getTitle(),
+                            item.getAuthor(),
+                            item.getPublisher(),
+                            item.getCover(),
+                            item.getDescription(),
+                            totalPages,
+                            pubDate,
+                            item.getItemId() != null ? String.valueOf(item.getItemId()) : null,
+                            item.getCategoryName()
+                    );
+                    return bookRepository.save(book);
+                });
+    }
+    //맵버 찾거나 없으면 null
+    private Member getMemberOrNull(Long memberUserId) {
+        return memberRepository.findByMemberUserId(memberUserId).orElse(null);
+    }
+
+
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -4,21 +4,28 @@ import com.shelfeed.backend.domain.book.client.AladinApiClient;
 import com.shelfeed.backend.domain.book.client.dto.AladinItem;
 import com.shelfeed.backend.domain.book.client.dto.AladinSearchResponse;
 import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
+import com.shelfeed.backend.domain.book.dto.respond.BookDetailResponse;
 import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
 import com.shelfeed.backend.domain.book.dto.respond.BookSummaryResponse;
 import com.shelfeed.backend.domain.book.entity.Book;
 import com.shelfeed.backend.domain.book.repository.BookRepository;
+import com.shelfeed.backend.domain.library.entity.LibraryBook;
+import com.shelfeed.backend.domain.library.enums.ReadingStatus;
 import com.shelfeed.backend.domain.library.repository.LibraryRepository;
 import com.shelfeed.backend.domain.member.entity.Member;
 import com.shelfeed.backend.domain.member.repository.MemberRepository;
+import com.shelfeed.backend.domain.review.entity.Review;
 import com.shelfeed.backend.domain.review.repository.ReviewLikeRepository;
 import com.shelfeed.backend.domain.review.repository.ReviewRepository;
+import com.shelfeed.backend.global.common.exception.BusinessException;
+import com.shelfeed.backend.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -54,12 +61,33 @@ public class BookService {
     }
 
 
-
-
-
-
-
     // 2. 도서 상세 조회
+    public BookDetailResponse getBook(Long bookId, Long memberUserId) {
+        //책 없으면 예외
+        Book book = bookRepository.findById(bookId).orElseThrow(()->new BusinessException(ErrorCode.BOOK_NOT_FOUND));
+        Double averageRating = bookRepository.findAverageRatingByBookId(bookId);//평균 별점
+        Long reviewCount = bookRepository.countReviewsByBookId(bookId);//리뷰 카운트
+        ReadingStatus myLibraryStatus = null;
+        Long myReviewId = null;
+
+        if (memberUserId != null){Member member = getMemberOrNull(memberUserId);//멤버 있으면 넣고 없으면 null
+            if (member != null){
+
+                Optional<LibraryBook> libraryBook = libraryRepository.findByMemberIdAndBook_BookId(member,bookId);
+                if (libraryBook.isPresent()){//isPresent : Optional에 데이터가 있으면 true 없으면 false
+                    myLibraryStatus = libraryBook.get().getStatus();
+                    }
+
+                Optional<Review> myReview = reviewRepository.findByMemberAndBook_BookIdAndIsDeletedFalse(member,bookId);
+                if (myReview.isPresent()){
+                    myReviewId = myReview.get().getReviewId();
+                }
+            }
+        }
+        return BookDetailResponse.of(book,averageRating,reviewCount,myLibraryStatus,myReviewId);
+    }
+
+
     // 3. ISBN 조회
     // 4. 도서별 감상 목록
 

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -3,10 +3,9 @@ package com.shelfeed.backend.domain.book.service;
 import com.shelfeed.backend.domain.book.client.AladinApiClient;
 import com.shelfeed.backend.domain.book.client.dto.AladinItem;
 import com.shelfeed.backend.domain.book.client.dto.AladinSearchResponse;
+import com.shelfeed.backend.domain.book.dto.request.BookReviewSearchRequest;
 import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
-import com.shelfeed.backend.domain.book.dto.respond.BookDetailResponse;
-import com.shelfeed.backend.domain.book.dto.respond.BookSearchListResponse;
-import com.shelfeed.backend.domain.book.dto.respond.BookSummaryResponse;
+import com.shelfeed.backend.domain.book.dto.respond.*;
 import com.shelfeed.backend.domain.book.entity.Book;
 import com.shelfeed.backend.domain.book.repository.BookRepository;
 import com.shelfeed.backend.domain.library.entity.LibraryBook;
@@ -20,6 +19,8 @@ import com.shelfeed.backend.domain.review.repository.ReviewRepository;
 import com.shelfeed.backend.global.common.exception.BusinessException;
 import com.shelfeed.backend.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,7 +111,25 @@ public class BookService {
     }
 
     // 4. 도서별 감상 목록
+    public BookReviewListResponse getBookReviews(Long bookId, BookReviewSearchRequest request, Long memberUserId){
+        if (!bookRepository.existsById(bookId)){
+            throw new BusinessException(ErrorCode.BOOK_NOT_FOUND);
+        }
+        int pageSize = request.getLimit() + 1;
+        List<Review> reviews = switch (request.getSort()){//필터링
+            case "popular" -> reviewRepository.findBookReviewsPopular(bookId, request.getCursor(), PageRequest.of(0,pageSize));
+            case "rating_high" -> reviewRepository.findBookReviewsRatingHigh(bookId, PageRequest.of(0, pageSize));
+            case "rating_low"  -> reviewRepository.findBookReviewsRatingLow(bookId, PageRequest.of(0, pageSize));
+            default -> reviewRepository.findBookReviewsLatest(
+                    bookId, request.getCursor(), PageRequest.of(0, pageSize));
+        };
+        List<BookReviewResponse> content = reviews.stream().map(review -> {
+                    boolean isLiked = memberUserId != null && reviewLikeRepository.existsByReview_ReviewIdAndMember_MemberUserId(review.getReviewId(), memberUserId);
+                    return BookReviewResponse.of(review, isLiked);
+                }).toList();
 
+        return BookReviewListResponse.of(content, request.getLimit());
+    }
 
     // 알라딘 아이템 → DB Book (없으면 저장)
     private Book findOrCreateBook(AladinItem item) {
@@ -142,6 +161,4 @@ public class BookService {
     private Member getMemberOrNull(Long memberUserId) {
         return memberRepository.findByMemberUserId(memberUserId).orElse(null);
     }
-
-
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -87,8 +87,28 @@ public class BookService {
         return BookDetailResponse.of(book,averageRating,reviewCount,myLibraryStatus,myReviewId);
     }
 
-
     // 3. ISBN 조회
+    @Transactional
+    public BookDetailResponse getBookByIsbn(String isbn13, Long memberUserId) {
+        Optional<Book> existing = bookRepository.findByIsbn13(isbn13);
+        Book book = existing.orElseGet(() -> {
+            AladinSearchResponse response = aladinApiClient.lookupByIsbn(isbn13);
+            if (response == null || response.getItems() == null || response.getItems().isEmpty()) {
+                throw new BusinessException(ErrorCode.BOOK_NOT_FOUND);
+            }
+            return findOrCreateBook(response.getItems().get(0));
+        });
+
+        boolean inMyLibrary = false;
+        if (memberUserId != null) {
+            Member member = getMemberOrNull(memberUserId);
+            if (member != null) {
+                inMyLibrary = libraryRepository.existsByMemberIdAndBook_BookId(member, book.getBookId());
+            }
+        }
+        return BookDetailResponse.ofIsbn(book, inMyLibrary);
+    }
+
     // 4. 도서별 감상 목록
 
 

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -20,7 +20,6 @@ import com.shelfeed.backend.global.common.exception.BusinessException;
 import com.shelfeed.backend.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
@@ -34,6 +34,8 @@ public interface LibraryRepository extends JpaRepository<LibraryBook,Long> {
     List<LibraryBook> findUserLibrary(@Param("member") Member member, @Param("status") ReadingStatus status,
                                       @Param("cursor") Long cursor,
                                       Pageable pageable);
+    Optional<LibraryBook> findByMemberIdAndBook_BookId(Member member,Long bookId);
+
 
 }
 

--- a/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewRepository.java
@@ -33,4 +33,55 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findUserReviews(@Param("member") Member member, @Param("cursor") Long cursor,
                                  Pageable pageable);
     Optional<Review> findByReviewIdAndIsDeletedFalse(Long reviewId);
+
+    //최신순(커서 기반)
+    @Query("""
+        SELECT r from Review r WHERE r.book.bookId = :bookId
+        AND r.isDeleted = false
+        AND r.reviewVisibility = 'PUBLIC'
+        AND r.reviewStatus = 'PUBLISHED'
+        AND(:cursor IS NULL OR r.reviewId < :cursor)
+        ORDER BY r.reviewId DESC
+""")
+    List<Review> findBookReviewsLatest(@Param("bookId") Long bookId,
+                                       @Param("cursor") Long cursor,
+                                       Pageable pageable);
+
+    //인기순(커서 기반)
+    @Query("""
+        SELECT r from Review r WHERE r.book.bookId = :bookId
+        AND r.isDeleted = false
+        AND r.reviewVisibility = 'PUBLIC'
+        AND r.reviewStatus = 'PUBLISHED'
+        AND(:cursor IS NULL OR r.likeCount < :cursor)
+        ORDER BY r.likeCount DESC
+""")
+    List<Review> findBookReviewsPopular(@Param("bookId") Long bookId,
+                                       @Param("cursor") Long cursor,
+                                       Pageable pageable);
+
+
+
+    //평점이 높은 순(Offset 기반 페이징) 겹치는 값이 많기도하고 유저들이 평점 낮은 거 까지 볼까?
+    @Query("""
+        SELECT r from Review r WHERE r.book.bookId = :bookId
+        AND r.isDeleted = false
+        AND r.reviewVisibility = 'PUBLIC'
+        AND r.reviewStatus = 'PUBLISHED'
+        ORDER BY r.rating DESC, r.reviewId DESC
+""")
+    List<Review> findBookReviewsRatingHigh(@Param("bookId") Long bookId,
+                                       Pageable pageable);
+
+    //평점이 낮은 순(Offset 기반 페이징) 겹치는 값이 많기도하고 유저들이 평점 낮은 거 까지 볼까?
+    @Query("""
+        SELECT r from Review r WHERE r.book.bookId = :bookId
+        AND r.isDeleted = false
+        AND r.reviewVisibility = 'PUBLIC'
+        AND r.reviewStatus = 'PUBLISHED'
+        ORDER BY r.rating ASC, r.reviewId DESC
+""")
+    List<Review> findBookReviewsRatingLow(@Param("bookId") Long bookId,
+                                       Pageable pageable);
+
 }

--- a/src/main/java/com/shelfeed/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/shelfeed/backend/global/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
             "/api/v1/auth/password/**",
             "/api/v1/auth/oauth2/**",
             "/api/v1/members/*/library",
+            "/api/v1/books/**",
     };
 
     @Bean

--- a/src/main/java/com/shelfeed/backend/global/config/WebConfig.java
+++ b/src/main/java/com/shelfeed/backend/global/config/WebConfig.java
@@ -2,13 +2,30 @@ package com.shelfeed.backend.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
 
 @Configuration
 public class WebConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 알라딘 API는 Content-Type: text/javascript 로 JSON을 반환 → Jackson이 처리할 수 있도록 추가
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setSupportedMediaTypes(List.of(
+                MediaType.APPLICATION_JSON,
+                MediaType.TEXT_PLAIN,
+                new MediaType("text", "javascript"),
+                new MediaType("application", "javascript"),
+                MediaType.TEXT_HTML
+        ));
+        restTemplate.getMessageConverters().add(0, converter);
+
+        return restTemplate;
     }
 }

--- a/src/main/java/com/shelfeed/backend/global/config/WebConfig.java
+++ b/src/main/java/com/shelfeed/backend/global/config/WebConfig.java
@@ -1,0 +1,14 @@
+package com.shelfeed.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
[문제점] - ai가 정리

1. Jackson 역직렬화 실패 (@Setter 누락)

  영향: content: [] 빈 결과

  AladinSearchResponse, AladinItem, SubInfo 클래스에 @Setter가 없었습니다. Jackson은 JSON
  → Java 객체 변환 시 setter를 통해 값을 주입하는데, setter가 없으니 모든 필드가 null로
  남아 items = null → 빈 리스트 반환.

  ---
  2. @ModelAttribute 바인딩 실패 (@Setter 누락)

  영향: query가 항상 null → 알라딘 API에 빈 검색어 전달

  BookSearchRequest, BookReviewSearchRequest에도 @Setter가 없었습니다. Spring의
  @ModelAttribute는 쿼리 파라미터를 객체에 바인딩할 때 setter를 사용합니다. setter가
  없으니 query = null로 API 호출.

  ---
  3. Content-Type 불일치 (RestTemplate 설정 미흡)

  영향: Jackson이 응답을 파싱 못 함

  알라딘 API는 JSON이지만 Content-Type: text/javascript로 응답합니다. Spring 기본
  RestTemplate은 application/json만 Jackson으로 처리하므로, text/javascript 응답은
  역직렬화 대상에서 제외됨.

  → WebConfig에 text/javascript 지원 converter 추가로 해결.

  ---
  4. 한글 이중 인코딩

  영향: 영어는 되는데 한글 검색 결과 없음

  UriComponentsBuilder.toUriString() + restTemplate.getForObject(String) 조합이
  문제였습니다.
  - toUriString() → 한글을 %EC%9E%90...으로 1차 인코딩
  - getForObject(String) → %를 다시 인코딩 → %25EC%259E%2590... (이중 인코딩)
  - 알라딘 API가 알아볼 수 없는 값 → 결과 없음

  → .encode().build().toUri() + getForObject(URI) 로 변경해 한 번만 인코딩.

  ---
  5. .env 파일 포맷 깨짐

  DB_URL이 줄바꿈으로 잘려있고 DB_USERNAME, DB_PASSWORD에 앞에 공백이 붙어 환경변수를 못
  읽는 구조 → 한 줄로 정리.