### PR TITLE
refactor1

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.security.SecureRandom;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -323,8 +324,10 @@ public class AuthService {
     }
 
     //기타
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private String generateSixDigitCode(){
-        return String.format("%06d", (int) (Math.random() * 1_000_000));//무작위 6자리 수 만듦
+        return String.format("%06d", SECURE_RANDOM.nextInt(1_000_000));//무작위 6자리 수 만듦
     }
 
     public record TokenPair(SignupResponse response, String refreshToken){}

--- a/src/main/java/com/shelfeed/backend/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/repository/BookRepository.java
@@ -36,6 +36,9 @@ SELECT AVG(r.rating) FROM Review r WHERE r.book.bookId = :bookId AND r.isDeleted
                            @Param("cursor") Long cursor,
                            Pageable pageable);
 
+    // ISBN 목록으로 일괄 조회 (N+1 방지)
+    List<Book> findByIsbn13In(List<String> isbn13List);
+
     // 도서 목록의 평점/리뷰수 일괄 조회 (N+1 방지)
     @Query("""
     SELECT r.book.bookId, AVG(r.rating), COUNT(r)

--- a/src/main/java/com/shelfeed/backend/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/repository/BookRepository.java
@@ -27,12 +27,24 @@ SELECT AVG(r.rating) FROM Review r WHERE r.book.bookId = :bookId AND r.isDeleted
 
     //도서 검색 쿼리
     @Query("""
-    SELECT b FROM Book b 
-    WHERE (b.title LIKE %:query% OR b.author LIKE %:query%) 
+    SELECT b FROM Book b
+    WHERE (b.title LIKE %:query% OR b.author LIKE %:query%)
     AND (:cursor IS NULL OR b.bookId < :cursor)
-    ORDER BY b.bookId DESC 
+    ORDER BY b.bookId DESC
 """)// %Like% 이기에 풀스캔을 때리는 상황이 발생해서 나중에 리팩토링 하겠습니다.
     List<Book> searchBooks(@Param("query") String query,
                            @Param("cursor") Long cursor,
                            Pageable pageable);
+
+    // 도서 목록의 평점/리뷰수 일괄 조회 (N+1 방지)
+    @Query("""
+    SELECT r.book.bookId, AVG(r.rating), COUNT(r)
+    FROM Review r
+    WHERE r.book IN :books
+    AND r.isDeleted = false
+    AND r.reviewVisibility = 'PUBLIC'
+    AND r.reviewStatus = 'PUBLISHED'
+    GROUP BY r.book.bookId
+""")
+    List<Object[]> findReviewStatsByBooks(@Param("books") List<Book> books);
 }

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -24,8 +24,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,21 +48,48 @@ public class BookService {
     // 1. 도서 검색
     @Transactional
     public BookSearchListResponse searchBooks(BookSearchRequest request, Long memberUserId) {
-        AladinSearchResponse response = aladinApiClient.search(request.getQuery(), 1 , request.getLimit() +1); //무한스크롤을 위해 +1 개 더 조회
-    if (response == null || response.getItems() == null) {
-        return BookSearchListResponse.of(List.of(), request.getLimit());// 내용없으면 빈 리스트
-    }
+        AladinSearchResponse response = aladinApiClient.search(request.getQuery(), 1, request.getLimit() + 1); //무한스크롤을 위해 +1 개 더 조회
+        if (response == null || response.getItems() == null) {
+            return BookSearchListResponse.of(List.of(), request.getLimit());// 내용없으면 빈 리스트
+        }
 
-    List<Book> books = response.getItems().stream().map(this::findOrCreateBook).toList();//getItems들을 findOrCreateBook 넣어라
-    Member member= memberUserId != null ? getMemberOrNull(memberUserId) : null;//멤버 없으면 null 있으면 사용
+        List<AladinItem> items = response.getItems();
 
-    //책이 유저의 서재에 담겨 있는가
-    List<BookSummaryResponse> content = books.stream().map(book -> { //각 책들을
-        boolean inMyLibrary = member != null && libraryRepository.existsByMemberIdAndBook_BookId(member, book.getBookId());//로그인이 되어있고 회원이 저장한 책이라면
-        return BookSummaryResponse.of(book,inMyLibrary);
-    }).toList();
+        //ISBN 목록으로 기존 도서 일괄 조회
+        List<String> isbns = items.stream().map(AladinItem::getIsbn13).toList();
+        Map<String, Book> existingBooks = bookRepository.findByIsbn13In(isbns).stream()
+                .collect(Collectors.toMap(Book::getIsbn13, b -> b));
 
-    return BookSearchListResponse.of(content, request.getLimit());
+        // DB에 없는 도서만 일괄 저장
+        List<Book> newBooks = items.stream()
+                .filter(item -> !existingBooks.containsKey(item.getIsbn13()))
+                .map(this::createBookFromItem)
+                .toList();
+        if (!newBooks.isEmpty()) bookRepository.saveAll(newBooks);
+
+        // 전체 도서 목록 구성 (기존 + 신규)
+        Map<String, Book> allBooksMap = new HashMap<>(existingBooks);
+        newBooks.forEach(b -> allBooksMap.put(b.getIsbn13(), b));
+        List<Book> allBooks = items.stream()
+                .map(item -> allBooksMap.get(item.getIsbn13()))
+                .filter(Objects::nonNull)
+                .toList();
+
+        Member member = memberUserId != null ? getMemberOrNull(memberUserId) : null;
+
+        // 서재 여부 IN절 일괄 조회
+        Set<Long> myLibraryBookIds = Set.of();
+        if (member != null && !allBooks.isEmpty()) {
+            List<Long> bookIds = allBooks.stream().map(Book::getBookId).toList();
+            myLibraryBookIds = libraryRepository.findBookIdsByMemberAndBookIdIn(member, bookIds);
+        }
+
+        final Set<Long> finalMyLibraryBookIds = myLibraryBookIds;
+        List<BookSummaryResponse> content = allBooks.stream()
+                .map(book -> BookSummaryResponse.of(book, finalMyLibraryBookIds.contains(book.getBookId())))
+                .toList();
+
+        return BookSearchListResponse.of(content, request.getLimit());
     }
 
 
@@ -130,7 +162,22 @@ public class BookService {
         return BookReviewListResponse.of(content, request.getLimit());
     }
 
-    // 알라딘 아이템 → DB Book (없으면 저장)
+    // 알라딘 아이템 → Book 엔티티 생성 (저장 없이 객체만 반환, saveAll용)
+    private Book createBookFromItem(AladinItem item) {
+        LocalDate pubDate = null;
+        try {
+            pubDate = LocalDate.parse(item.getPubDate());
+        } catch (Exception ignored) {}
+        Integer totalPages = item.getSubInfo() != null ? item.getSubInfo().getItemPage() : null;
+        return Book.create(
+                item.getIsbn13(), item.getTitle(), item.getAuthor(), item.getPublisher(),
+                item.getCover(), item.getDescription(), totalPages, pubDate,
+                item.getItemId() != null ? String.valueOf(item.getItemId()) : null,
+                item.getCategoryName()
+        );
+    }
+
+    // 알라딘 아이템 → DB Book (없으면 저장) - 단건 조회용 (getBookByIsbn 등)
     private Book findOrCreateBook(AladinItem item) {
         return bookRepository.findByIsbn13(item.getIsbn13())
                 .orElseGet(() -> {

--- a/src/main/java/com/shelfeed/backend/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/comment/repository/CommentLikeRepository.java
@@ -2,13 +2,21 @@ package com.shelfeed.backend.domain.comment.repository;
 
 import com.shelfeed.backend.domain.comment.entity.CommentLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike,Long> {
 
     boolean existsByComment_CommentIdAndMember_MemberUserId(Long commentId, Long memberUserId);//중복 조회
 
     Optional<CommentLike> findByComment_CommentIdAndMember_MemberUserId(Long commentId, Long memberUserId); //삭제 대상 조회 용도
+
+    // 좋아요 IN절 일괄 조회 (N+1 방지)
+    @Query("SELECT cl.comment.commentId FROM CommentLike cl WHERE cl.comment.commentId IN :commentIds AND cl.member.memberUserId = :memberUserId")
+    Set<Long> findLikedCommentIds(@Param("commentIds") List<Long> commentIds, @Param("memberUserId") Long memberUserId);
 
 }

--- a/src/main/java/com/shelfeed/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/comment/repository/CommentRepository.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment,Long> {
     //특벙 감상의 원 댓글만 골라서 조회(페이지네이션 방식으로)
-    @Query(""" 
-            SELECT c FROM Comment c
+    @Query("""
+            SELECT c FROM Comment c JOIN FETCH c.member
             WHERE c.review = :review
             AND c.parentComment IS NULL
             AND (:cursor IS NULL OR c.commentId < :cursor)
@@ -23,6 +23,10 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
 
     // 대댓글 조회
     List<Comment> findByParentComment(Comment parentComment);
+
+    // 대댓글 IN절 일괄 조회 (N+1 방지)
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.parentComment IN :parents ORDER BY c.commentId ASC")
+    List<Comment> findRepliesByParents(@Param("parents") List<Comment> parents);
 
     // 삭제 안된 감상 조회
     Optional<Comment> findByCommentIdAndIsDeletedFalse(Long commentId);

--- a/src/main/java/com/shelfeed/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/shelfeed/backend/domain/comment/service/CommentService.java
@@ -19,7 +19,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.shelfeed.backend.domain.comment.entity.QComment.comment;
 
@@ -58,24 +62,42 @@ public class CommentService {
     public CommentListResponse getComments(Long reviewId, Long cursor, int limit, Long memberUserId){
         Review review = getReview(reviewId);
 
-        List<Comment> parentComments = commentRepository.findParentComments(review,cursor, PageRequest.of(0, limit + 1));
+        List<Comment> parentComments = commentRepository.findParentComments(review, cursor, PageRequest.of(0, limit + 1));
+        boolean hasNext = parentComments.size() > limit;
+        if (hasNext) parentComments = parentComments.subList(0, limit);
 
-        List<CommentResponse> content = parentComments.stream().map(comment ->{
-                    //로그인 한 사람인가
-                    boolean isMine = memberUserId != null && comment.getMember().getMemberUserId().equals(memberUserId);
-                    //좋아요 누른 사람인가
-                    boolean isLiked = memberUserId != null && commentLikeRepository.existsByComment_CommentIdAndMember_MemberUserId(comment.getCommentId(),memberUserId);
+        // 대댓글 IN절 일괄 조회
+        List<Comment> allReplies = parentComments.isEmpty()
+                ? List.of()
+                : commentRepository.findRepliesByParents(parentComments);
+        Map<Long, List<Comment>> repliesMap = allReplies.stream()
+                .collect(Collectors.groupingBy(r -> r.getParentComment().getCommentId()));
 
-                    List<ReplyResponse> replies = commentRepository.findByParentComment(comment).stream().map(reply -> {
-                        //로그인 한 유저 그리고 답글의 유저가 기존 멤버인가
+        // 좋아요 IN절 일괄 조회 (부모 댓글 + 대댓글 한번에)
+        Set<Long> likedIds = Set.of();
+        if (memberUserId != null) {
+            List<Long> allCommentIds = new ArrayList<>();
+            parentComments.forEach(c -> allCommentIds.add(c.getCommentId()));
+            allReplies.forEach(r -> allCommentIds.add(r.getCommentId()));
+            if (!allCommentIds.isEmpty()) {
+                likedIds = commentLikeRepository.findLikedCommentIds(allCommentIds, memberUserId);
+            }
+        }
+
+        final Set<Long> finalLikedIds = likedIds;
+        List<CommentResponse> content = parentComments.stream().map(comment -> {
+            boolean isMine = memberUserId != null && comment.getMember().getMemberUserId().equals(memberUserId);
+            boolean isLiked = finalLikedIds.contains(comment.getCommentId());
+
+            List<ReplyResponse> replies = repliesMap.getOrDefault(comment.getCommentId(), List.of()).stream()
+                    .map(reply -> {
                         boolean replyIsMine = memberUserId != null && reply.getMember().getMemberUserId().equals(memberUserId);
-                        // 로그인 한 유저 그리고 좋아요를 눌렀는가
-                        boolean replyIsLiked = memberUserId != null && commentLikeRepository.existsByComment_CommentIdAndMember_MemberUserId(reply.getCommentId(),memberUserId);
-                        return ReplyResponse.of(reply,replyIsMine,replyIsLiked);
-                }).toList();
-                    return CommentResponse.of(comment,isMine,isLiked,replies);
+                        boolean replyIsLiked = finalLikedIds.contains(reply.getCommentId());
+                        return ReplyResponse.of(reply, replyIsMine, replyIsLiked);
+                    }).toList();
+            return CommentResponse.of(comment, isMine, isLiked, replies);
         }).toList();
-        return CommentListResponse.of(content,limit);
+        return CommentListResponse.of(content, limit);
     }
 
     // 3. 댓글 수정

--- a/src/main/java/com/shelfeed/backend/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/feed/repository/FeedRepository.java
@@ -4,12 +4,14 @@ import com.shelfeed.backend.domain.feed.entity.Feed;
 import com.shelfeed.backend.domain.follow.entity.Follow;
 import com.shelfeed.backend.domain.member.entity.Member;
 import com.shelfeed.backend.domain.review.entity.Review;
+import com.shelfeed.backend.domain.review.entity.ReviewTag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
     // 피드 목록 커서 페이지네이션
@@ -20,6 +22,16 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 """)
     List<Feed> findFeed(@Param("member") Member member, @Param("cursor") Long cursor,
                         Pageable pageable);
+    //패치조인 쿼리 추가
+    @Query("""
+    SELECT f FROM Feed f JOIN FETCH f.review r JOIN FETCH r.member JOIN FETCH r.book
+    WHERE f.member = :member
+    AND (:cursor IS NULL OR f.feedId < :cursor)
+    ORDER BY f.feedId DESC
+""")List<Feed> findFeedWithDetails(@Param("member") Member member,
+                                   @Param("cursor") Long cursor,
+                                   Pageable pageable);
+
 
     //언팔로우 한 사용자 감상 피드에서 제거
     void deleteByMemberAndReview_Member(Member follower, Member followee);

--- a/src/main/java/com/shelfeed/backend/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shelfeed/backend/domain/feed/service/FeedService.java
@@ -6,6 +6,7 @@ import com.shelfeed.backend.domain.feed.entity.Feed;
 import com.shelfeed.backend.domain.feed.repository.FeedRepository;
 import com.shelfeed.backend.domain.member.entity.Member;
 import com.shelfeed.backend.domain.member.repository.MemberRepository;
+import com.shelfeed.backend.domain.review.entity.ReviewTag;
 import com.shelfeed.backend.domain.review.repository.ReviewLikeRepository;
 import com.shelfeed.backend.domain.review.repository.ReviewTagRepository;
 import com.shelfeed.backend.global.common.exception.BusinessException;
@@ -15,7 +16,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,20 +36,30 @@ public class FeedService {
     public FeedListResponse getFollowingFeed(Long memberUserId, Long cursor, int limit) {
         Member member = getMember(memberUserId);
         //피드페이지
-        List<Feed> feeds = feedRepository.findFeed(member,cursor, PageRequest.of(0, limit +1));
+        //패치 조인으로 피드랑 감상 가져오기
+        List<Feed> feeds = feedRepository.findFeedWithDetails(member,cursor, PageRequest.of(0, limit +1));
+        // 리뷰 아이디만 뽑기(in절에 사용하려고)
+        List<Long> reviewIds = feeds.stream().map(feed -> feed.getReview().getReviewId()).toList();
+        //in절로 좋아요 조회
+        Set<Long> likedReviewIds = reviewLikeRepository.findLikedReviewIds(reviewIds, memberUserId);
+        //태그 목록 in 절
+        List<ReviewTag> allTags = reviewTagRepository.findByReviewIdIn(reviewIds);
+        Map<Long, List<String>> tagMap = allTags.stream()
+                .collect(Collectors.groupingBy(
+                        rt -> rt.getReview().getReviewId(),
+                        Collectors.mapping(rt -> rt.getTag().getTagName(), Collectors.toList())
+                ));
+        //최종
         List<FeedItemResponse> content = feeds.stream().map(feed -> {
             Long reviewId = feed.getReview().getReviewId();
+            boolean isLiked = likedReviewIds.contains(reviewId);
+            List<String> tags = tagMap.getOrDefault(reviewId, Collections.emptyList());
 
-            // 내가 감상에 좋아요를 눌렀는 가
-            boolean isLiked = reviewLikeRepository.existsByReview_ReviewIdAndMember_MemberUserId(reviewId,memberUserId);
-
-            // 감상에 달린 테그 목록
-            List<String> tag = reviewTagRepository.findByReview(feed.getReview()).stream()
-                    .map(rt -> rt.getTag().getTagName()).toList();
-            return FeedItemResponse.of(feed, isLiked, tag);
-
+            return FeedItemResponse.of(feed, isLiked, tags);
         }).toList();
-        return FeedListResponse.of(content,limit);
+
+        return FeedListResponse.of(content, limit);
+
     }
 
     private Member getMember(Long memberUserId) {

--- a/src/main/java/com/shelfeed/backend/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/follow/repository/FollowRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface FollowRepository extends JpaRepository<Follow,Long> {
 
@@ -33,6 +34,36 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
 """)
     List<Follow> findFollowings(@Param("member") Member member, @Param("cursor") Long cursor,
                                Pageable pageable);
+
+    //패치 조인  팔로워 조회 시 멤버 정보 한 번에
+    @Query("""
+    SELECT f FROM Follow f 
+    JOIN FETCH f.follower 
+    WHERE f.followee = :target AND f.followId < :cursor
+    """)
+    List<Follow> findFollowersWithMember(@Param("target") Member target,
+                                         @Param("cursor") Long cursor,
+                                         Pageable pageable);
+
+    //내가 타인을 팔로우 중인지 (Following 여부)
+    @Query("""
+    SELECT f.followee.memberUserId FROM Follow f 
+    WHERE f.follower = :me AND f.followee IN :candidates
+    """)
+    Set<Long> findFollowingIds(@Param("me") Member me,
+                               @Param("candidates") List<Member> candidates);
+
+    //타인이 나를 팔로우 중인지 (Follower 여부)
+    @Query("""
+    SELECT f.follower.memberUserId FROM Follow f 
+    WHERE f.followee = :me AND f.follower IN :candidates
+    """)
+    Set<Long> findFollowedByIds(@Param("me") Member me,
+                                @Param("candidates") List<Member> candidates);
+
+
+
+
 
     //타 유저의 팔로워 조회
     List<Follow> findByFollowee(Member followee);

--- a/src/main/java/com/shelfeed/backend/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/follow/repository/FollowRepository.java
@@ -35,6 +35,18 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     List<Follow> findFollowings(@Param("member") Member member, @Param("cursor") Long cursor,
                                Pageable pageable);
 
+    // 팔로잉 목록 + followee JOIN FETCH (N+1 방지)
+    @Query("""
+    SELECT f FROM Follow f
+    JOIN FETCH f.followee
+    WHERE f.follower = :target
+    AND (:cursor IS NULL OR f.followId < :cursor)
+    ORDER BY f.followId DESC
+""")
+    List<Follow> findFollowingsWithMember(@Param("target") Member target,
+                                          @Param("cursor") Long cursor,
+                                          Pageable pageable);
+
     //패치 조인  팔로워 조회 시 멤버 정보 한 번에
     @Query("""
     SELECT f FROM Follow f 

--- a/src/main/java/com/shelfeed/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/com/shelfeed/backend/domain/follow/service/FollowService.java
@@ -109,20 +109,33 @@ public class FollowService {
     //4.팔로잉 목록
     public FollowListResponse getFollowings(Long targetUserId, Long cursor, int limit, Long memberUserId){
         Member target = getMember(targetUserId);
-        //팔로워 페이지
-        List<Follow> follows = followRepository.findFollowings(target, cursor, PageRequest.of(0, limit + 1));
-        //팔로워 목록에 표기할 유저
-        List<FollowMemberResponse> content = follows.stream().map(follow ->{
-            Member followee = follow.getFollowee();
-            //현재 팔로우 중인지
-            boolean isFollowing = memberUserId != null && followRepository.existsByFollowerAndFollowee(getMember(memberUserId), followee);
-            //타 유저가 나를 팔로우 중인지
-            boolean isFollowBy = memberUserId != null && followRepository.existsByFollowerAndFollowee(followee,getMember(memberUserId));
+        // 사용자 정보 1번만 조회
+        Member me = (memberUserId != null) ? getMember(memberUserId) : null;
+        // 팔로잉 목록 조회 (패치조인)
+        List<Follow> follows = followRepository.findFollowingsWithMember(target, cursor, PageRequest.of(0, limit + 1));
+        // 대상이 되는 팔로잉 리스트 추출
+        List<Member> candidates = follows.stream().map(Follow::getFollowee).toList();
+        // 팔로우 관계 IN절
+        Set<Long> followingIds = Collections.emptySet();
+        Set<Long> followedByIds = Collections.emptySet();
 
+        if (me != null && !candidates.isEmpty()) {
+            followingIds = followRepository.findFollowingIds(me, candidates);
+            followedByIds = followRepository.findFollowedByIds(me, candidates);
+        }
+
+        final Set<Long> finalFollowingIds = followingIds;
+        final Set<Long> finalFollowedByIds = followedByIds;
+
+        List<FollowMemberResponse> content = follows.stream().map(follow -> {
+            Member followee = follow.getFollowee();
+            Long followeeId = followee.getMemberUserId();
+            boolean isFollowing = finalFollowingIds.contains(followeeId);
+            boolean isFollowBy = finalFollowedByIds.contains(followeeId);
             return FollowMemberResponse.of(followee, isFollowing, isFollowBy);
         }).toList();
 
-        return  FollowListResponse.of(content,limit);
+        return FollowListResponse.of(content, limit);
     }
 
 

--- a/src/main/java/com/shelfeed/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/com/shelfeed/backend/domain/follow/service/FollowService.java
@@ -16,7 +16,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static com.shelfeed.backend.domain.follow.entity.QFollow.follow;
 
@@ -69,15 +71,34 @@ public class FollowService {
     //3.팔로워 목록
     public FollowListResponse getFollowers(Long targetUserId, Long cursor, int limit, Long memberUserId){
         Member target = getMember(targetUserId);
-        //팔로워 페이지
-        List<Follow> follows = followRepository.findFollowers(target, cursor, PageRequest.of(0, limit + 1));
+        //사용자 정보 1번만 조회
+        Member me = (memberUserId != null) ? getMember(memberUserId) : null;
+        //팔로워 목록 조회(패치조인)
+        List<Follow> follows = followRepository.findFollowersWithMember(target, cursor, PageRequest.of(0, limit + 1));
+        // 대상이 되는 팔러워 리스트 추출
+        List<Member> candidates = follows.stream().map(Follow::getFollower).toList();
+        //팔로우 관계 in 절
+        Set<Long> followingIds = Collections.emptySet();
+        Set<Long> followedByIds = Collections.emptySet();
+
+        if (me != null && !candidates.isEmpty()) {
+            followingIds = followRepository.findFollowingIds(me, candidates);
+            followedByIds = followRepository.findFollowedByIds(me, candidates);
+        }
+
+        final Set<Long> finalFollowingIds = followingIds;
+        final Set<Long> finalFollowedByIds = followedByIds;
+
+
         //팔로워 목록에 표기할 유저
         List<FollowMemberResponse> content = follows.stream().map(follow ->{
             Member follower = follow.getFollower();
+            Long followerId = follower.getMemberUserId();
+
             //현재 팔로우 중인지
-            boolean isFollowing = memberUserId != null && followRepository.existsByFollowerAndFollowee(getMember(memberUserId), follower);
+            boolean isFollowing = finalFollowingIds.contains(followerId);
             //타 유저가 나를 팔로우 중인지
-            boolean isFollowBy = memberUserId != null && followRepository.existsByFollowerAndFollowee(follower,getMember(memberUserId));
+            boolean isFollowBy = finalFollowedByIds.contains(followerId);
 
             return FollowMemberResponse.of(follower, isFollowing, isFollowBy);
         }).toList();

--- a/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface LibraryRepository extends JpaRepository<LibraryBook,Long> {
     //중복 확인
@@ -36,6 +37,9 @@ public interface LibraryRepository extends JpaRepository<LibraryBook,Long> {
                                       Pageable pageable);
     Optional<LibraryBook> findByMemberIdAndBook_BookId(Member member,Long bookId);
 
+    // 서재에 담긴 도서 ID 목록 일괄 조회 (N+1 방지)
+    @Query("SELECT lb.book.bookId FROM LibraryBook lb WHERE lb.memberId = :member AND lb.book.bookId IN :bookIds")
+    Set<Long> findBookIdsByMemberAndBookIdIn(@Param("member") Member member, @Param("bookIds") List<Long> bookIds);
 
 }
 

--- a/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/library/repository/LibraryRepository.java
@@ -15,26 +15,17 @@ import java.util.Set;
 public interface LibraryRepository extends JpaRepository<LibraryBook,Long> {
     //중복 확인
     boolean existsByMemberIdAndBook_BookId(Member member, Long bookId);
-    //내 서재 목록 JPQL
-    @Query("SELECT lb FROM LibraryBook lb WHERE lb.memberId = :member " +
+    // 서재 목록 공통 쿼리 (내 서재 / 타 유저 서재 공용, JOIN FETCH로 Book N+1 방지)
+    @Query("SELECT lb FROM LibraryBook lb JOIN FETCH lb.book WHERE lb.memberId = :member " +
             "AND (:status IS NULL OR lb.status = :status) " +//전체 조회 + 필터링 조회
             "AND (:cursor IS NULL OR lb.libraryBookId < :cursor) " + // 커서 페이지 네이션
             "ORDER BY lb.libraryBookId DESC")
-    List<LibraryBook> findMyLibrary(@Param("member") Member member, @Param("status") ReadingStatus status,
-                                    @Param("cursor") Long cursor,
-                                    Pageable pageable);
+    List<LibraryBook> findLibraryBooks(@Param("member") Member member, @Param("status") ReadingStatus status,
+                                       @Param("cursor") Long cursor,
+                                       Pageable pageable);
 
     //유저 본인의 서재인가 확인
     Optional<LibraryBook> findByLibraryBookIdAndMemberId(Long libraryBookId, Member member);
-
-    //타 유저 서재 목록
-    @Query("SELECT lb FROM LibraryBook lb WHERE lb.memberId = :member " +
-            "AND (:status IS NULL OR lb.status = :status) " +//전체 조회 + 필터링 조회
-            "AND (:cursor IS NULL OR lb.libraryBookId < :cursor) " +// 커서 페이지 네이션
-            "ORDER BY lb.libraryBookId DESC")
-    List<LibraryBook> findUserLibrary(@Param("member") Member member, @Param("status") ReadingStatus status,
-                                      @Param("cursor") Long cursor,
-                                      Pageable pageable);
     Optional<LibraryBook> findByMemberIdAndBook_BookId(Member member,Long bookId);
 
     // 서재에 담긴 도서 ID 목록 일괄 조회 (N+1 방지)

--- a/src/main/java/com/shelfeed/backend/domain/library/service/LibraryService.java
+++ b/src/main/java/com/shelfeed/backend/domain/library/service/LibraryService.java
@@ -49,7 +49,7 @@ public class LibraryService {
     public LibraryListResponse getMyLibrary(Long memberUserId, ReadingStatus status, Long cursor, int limit){
         Member member = getMember(memberUserId);
         //Id 기반 페이지 네이션
-        List<LibraryBook> books = libraryRepository.findMyLibrary(member,status,cursor, PageRequest.of(0,limit + 1));
+        List<LibraryBook> books = libraryRepository.findLibraryBooks(member, status, cursor, PageRequest.of(0, limit + 1));
 
         List<LibraryBookSummaryResponse> content = books.stream().map(LibraryBookSummaryResponse::of).toList();
 
@@ -99,7 +99,7 @@ public class LibraryService {
             return UserLibraryResponse.ofPrivate();
         }
 
-        List<LibraryBook> books = libraryRepository.findUserLibrary(member, status, cursor, PageRequest.of(0, limit + 1));
+        List<LibraryBook> books = libraryRepository.findLibraryBooks(member, status, cursor, PageRequest.of(0, limit + 1));
         List<LibraryBookSummaryResponse> content = books.stream().map(LibraryBookSummaryResponse::of).toList();
         return UserLibraryResponse.of(content, limit);
     }

--- a/src/main/java/com/shelfeed/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/member/repository/MemberRepository.java
@@ -17,7 +17,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     //닉네임 검색
     @Query("""
-    SELECT m FROM Memeber m WHERE m.nickname Like %:query%
+    SELECT m FROM Member m WHERE m.nickname Like %:query%
     AND (:cursor IS NULL OR m.memberUserId < :cursor)
     ORDER BY m.memberUserId DESC
 """)

--- a/src/main/java/com/shelfeed/backend/domain/review/entity/ReviewLike.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/entity/ReviewLike.java
@@ -35,13 +35,6 @@ public class ReviewLike {
     private LocalDateTime createdAt;
 
     //정적 메서드
-    public static ReviewLike reviewLike(Member member, Review review) {
-        ReviewLike reviewLike = new ReviewLike();
-        reviewLike.member = member;
-        reviewLike.review = review;
-        return reviewLike;
-    }
-
     public static ReviewLike create(Review review, Member member) {
         ReviewLike like = new ReviewLike();
         like.review = review;

--- a/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewLikeRepository.java
@@ -1,13 +1,26 @@
 package com.shelfeed.backend.domain.review.repository;
 
 import com.shelfeed.backend.domain.review.entity.ReviewLike;
+import com.shelfeed.backend.domain.review.entity.ReviewTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike,Long> {
 
     boolean existsByReview_ReviewIdAndMember_MemberUserId(Long reviewId, Long memberUserId);// 좋아요 중복확인
 
     Optional<ReviewLike> findByReview_ReviewIdAndMember_MemberUserId(Long reviewId, Long memberUserId);// 좋아요 취소 할 때 삭제 대상 조회용도
+
+    //감상 좋아요 in절
+    @Query("""
+    SELECT rl.review.reviewId FROM ReviewLike rl 
+    WHERE rl.review.reviewId IN :reviewIds AND rl.member.memberUserId = :userId
+""")
+    Set<Long> findLikedReviewIds(@Param("reviewIds") List<Long> reviewIds,
+                                 @Param("userId") Long userId);
 }

--- a/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewRepository.java
@@ -17,7 +17,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByMember_MemberUserIdAndBook_BookIdAndIsDeletedFalse(Long memberUserId, Long bookId);//서재 도서 삭제 시 감상 존재 여부 체크
     Optional<Review> findByMemberAndBook_BookIdAndIsDeletedFalse(Member member, Long bookId);
     //내 감상 목록 커서 페이지 네이션
-    @Query("SELECT r FROM Review r WHERE r.member = :member AND r.isDeleted = false " +
+    @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book " +
+            "WHERE r.member = :member AND r.isDeleted = false " +
             "AND (:status IS NULL OR r.reviewStatus = :status) " + // 프론트엔드가 특정 상태를 안 보내면 앞 조건이 참이 되어 전체를 다 보여주고, 특정 값을 보내면 딱 그 상태의 리뷰만 걸러내는 아주 똑똑한 선택적 검색 조건
             "AND (:cursor IS NULL OR r.reviewId < :cursor) " +// 무한 스크롤 커서
             "ORDER BY r.reviewId DESC")// 가장 최근에 쓴 최신 글 순서대로
@@ -26,7 +27,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
                                @Param("cursor") Long cursor,
                                Pageable pageable);
 
-    @Query("SELECT r FROM Review r WHERE r.member = :member AND r.isDeleted = false " +
+    @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book " +
+            "WHERE r.member = :member AND r.isDeleted = false " +
             "AND r.reviewVisibility = 'PUBLIC' AND r.reviewStatus = 'PUBLISHED' " +
             "AND (:cursor IS NULL OR r.reviewId < :cursor) " +
             "ORDER BY r.reviewId DESC")

--- a/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewTagRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/repository/ReviewTagRepository.java
@@ -3,6 +3,8 @@ package com.shelfeed.backend.domain.review.repository;
 import com.shelfeed.backend.domain.review.entity.Review;
 import com.shelfeed.backend.domain.review.entity.ReviewTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +13,10 @@ public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
     List<ReviewTag> findByReview(Review review);
 
     void deleteByReview(Review review);
+
+    //감상 태그 in절
+    @Query("""
+    SELECT rt FROM ReviewTag rt JOIN FETCH rt.tag
+    WHERE  rt.review.reviewId IN :reviewIds
+""")List<ReviewTag> findByReviewIdIn(@Param("reviewIds") List<Long> reviewIds);
 }

--- a/src/main/java/com/shelfeed/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/service/ReviewService.java
@@ -131,7 +131,6 @@ public class ReviewService {
         if (review.getReviewStatus() == ReviewStatus.PUBLISHED){
             review.getMember().decreaseReviewCount();
         }
-        review.softDelect();
         feedRepository.deleteByReview(review);
     }
     //5. 내 감상 목록

--- a/src/main/java/com/shelfeed/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/service/ReviewService.java
@@ -26,7 +26,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -138,7 +141,10 @@ public class ReviewService {
         boolean hasNext = reviews.size() > limit;// 다음 페이지 확인
         if (hasNext) reviews = reviews.subList(0, limit);// 한 개 빼기
 
-        return reviews.stream().map(review -> ReviewSummaryResponse.of(review,getTagNames(review))).toList();
+        Map<Long, List<String>> tagMap = getTagNamesByReviews(reviews);
+        return reviews.stream()
+                .map(review -> ReviewSummaryResponse.of(review, tagMap.getOrDefault(review.getReviewId(), Collections.emptyList())))
+                .toList();
     }
     //6. 타 유저 감상 목록
     public List<ReviewSummaryResponse> getUserReviews(Long userId, Long cursor, int limit) {
@@ -147,7 +153,10 @@ public class ReviewService {
         boolean hasNext = reviews.size() > limit;// 다음 페이지 확인
         if (hasNext) reviews = reviews.subList(0, limit);// 한 개 빼기
 
-        return reviews.stream().map(review -> ReviewSummaryResponse.of(review, getTagNames(review))).toList();
+        Map<Long, List<String>> tagMap = getTagNamesByReviews(reviews);
+        return reviews.stream()
+                .map(review -> ReviewSummaryResponse.of(review, tagMap.getOrDefault(review.getReviewId(), Collections.emptyList())))
+                .toList();
     }
     //7. 감상 좋아요
     @Transactional
@@ -200,10 +209,21 @@ public class ReviewService {
     private Review getReviewOrThrow(Long reviewId) {
         return reviewRepository.findByReviewIdAndIsDeletedFalse(reviewId).orElseThrow(()-> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
     }
-    //태그 이름 목록 조회
+    //태그 이름 목록 조회 (단건)
     private List<String> getTagNames(Review review) {
         return reviewTagRepository.findByReview(review).stream()
                 .map(reviewTag -> reviewTag.getTag().getTagName()).toList();
+    }
+
+    //태그 이름 목록 일괄 조회 (IN절 - N+1 방지)
+    private Map<Long, List<String>> getTagNamesByReviews(List<Review> reviews) {
+        if (reviews.isEmpty()) return Map.of();
+        List<Long> reviewIds = reviews.stream().map(Review::getReviewId).toList();
+        return reviewTagRepository.findByReviewIdIn(reviewIds).stream()
+                .collect(Collectors.groupingBy(
+                        rt -> rt.getReview().getReviewId(),
+                        Collectors.mapping(rt -> rt.getTag().getTagName(), Collectors.toList())
+                ));
     }
 }
 

--- a/src/main/java/com/shelfeed/backend/domain/search/service/SearchService.java
+++ b/src/main/java/com/shelfeed/backend/domain/search/service/SearchService.java
@@ -18,7 +18,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -58,13 +61,38 @@ public class SearchService {
     // 도서 검색
     private SearchPageResponse<BookSearchResult> searchBooks(String query, Long cursor, int limit) {
         List<Book> books = bookRepository.searchBooks(query, cursor, PageRequest.of(0, limit + 1));
-        //페이지네이션
+        // 페이지네이션 처리
         boolean hasNext = books.size() > limit;
         List<Book> result = hasNext ? books.subList(0, limit) : books;
-        List<BookSearchResult> content = result.stream().map(book ->
-                BookSearchResult.of(book, bookRepository.findAverageRatingByBookId(book.getBookId()),
-                        bookRepository.countReviewsByBookId(book.getBookId()))
-        ).toList();
+
+        // 결과가 비어있으면 불필요한 IN 쿼리를 날리지 않음
+        if (result.isEmpty()) {
+            return SearchPageResponse.empty();
+        }
+
+        //IN 절로 통계 데이터 한 번에 조회
+        List<Object[]> stats = bookRepository.findReviewStatsByBooks(result);
+
+        // O(1) 조회를 위해 Map으로 변환
+        Map<Long, Object[]> statsMap = stats.stream()
+                .collect(Collectors.toMap(
+                        stat -> (Long) stat[0], // 배열의 0번째 인덱스: bookId
+                        stat -> stat            // 배열 전체를 Value로 저장
+                ));
+
+        //메모리 내에서 매핑 작업 수행
+        List<BookSearchResult> content = result.stream().map(book -> {
+            Long bookId = book.getBookId();
+
+            // Map에서 해당 도서의 통계 데이터를 꺼냄 (리뷰가 아예 없는 책은 null일 수 있음)
+            Object[] stat = statsMap.get(bookId);
+
+            // DB에서 리뷰가 없어 통계 결과가 없는 경우 기본값 처리 (평점 0.0, 리뷰수 0)
+            Double avgRating = (stat != null && stat[1] != null) ? (Double) stat[1] : 0.0;
+            Long reviewCount = (stat != null && stat[2] != null) ? (Long) stat[2] : 0L;
+
+            return BookSearchResult.of(book, avgRating, reviewCount);
+        }).toList();
 
         Long nextCursor = hasNext ? result.get(result.size() - 1).getBookId() : null;
 

--- a/src/main/java/com/shelfeed/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/shelfeed/backend/global/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.shelfeed.backend.global.jwt;
 import com.shelfeed.backend.global.redis.RedisService;
 import com.shelfeed.backend.global.security.CustomUserDetailsService;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,7 +46,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             } catch (ExpiredJwtException e){
+                // 토큰 만료 시 명시적 401 처리
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // HTTP 401
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
 
+                // 프론트엔드가 파싱하기 쉬운 JSON 형태로 변환
+                String errorMessage = "{\"errorCode\": \"TOKEN_EXPIRED\", \"message\": \"액세스 토큰이 만료되었습니다. 토큰을 재발급해 주세요.\"}";
+                response.getWriter().write(errorMessage);
+                // 필터 체인 진행 중단
+                return;
+            } catch (JwtException | IllegalArgumentException e){
+                // 토큰 만료 시 명시적 401 처리
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+                // 프론트엔드가 파싱하기 쉬운 JSON 형태로 변환
+                String errorMessage = "{\"errorCode\": \"INVALID_TOKEN\", \"message\": \"유효하지 않은 토큰입니다.\"}";
+                response.getWriter().write(errorMessage);
+                // 필터 체인 진행 중단
+                return;
             }
         }
         filterChain.doFilter(request,response);


### PR DESCRIPTION
* Memeber 오타수정

* ChangeRandomToSecureRandom

* solveFeedPartN+1

* solveFollowPartN+1

* solveReviewPartN+1

* solveSearchPartN+1

* CommentAndBookPartN+1

* 중복 호출 제거

* 완전 중복 정적 팩토리 메서드 삭제

* 쿼리 중복 문제 해결

* JWT 만료 예외 처리

* solveFollowServiceN+1

패치조인과 in절
패치조인(1:1 또는 N:1 관계)

행 개수가 변하지 않는 관계는 한 번에 조인
in절(1:N 관계 또는 별개의 데이터)
태그처럼 하나의 피드에 여러개의 태그가 있을 시 행이 태그 개수 만큼 뻥튀기가 된다
좋아요 처럼 피드자체 정보보단 현재 사용자와의 관계데이터일때 join을 하면 쿼리가 복잡해져서
[페이지네이션과 패치조인]
ToOne : 데이터 뻥퀴기가 없어서 무조건 사용하는게 좋음
ToMany : 1:N 관계에서 조인을 하면 데이터는 뻥튀기 되는데 limit을 걸면 OO