### PR TITLE
feat/관심장르설정api

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/shelfeed/backend/domain/member/controller/MemberController.java
@@ -2,10 +2,12 @@ package com.shelfeed.backend.domain.member.controller;
 
 import com.shelfeed.backend.domain.member.dto.request.ChangePasswordRequest;
 import com.shelfeed.backend.domain.member.dto.request.OnboardingRequest;
+import com.shelfeed.backend.domain.member.dto.request.UpdateGenresRequest;
 import com.shelfeed.backend.domain.member.dto.request.UpdateProfileRequest;
 import com.shelfeed.backend.domain.member.dto.request.WithdrawRequest;
 import com.shelfeed.backend.domain.member.dto.response.MyProfileResponse;
 import com.shelfeed.backend.domain.member.dto.response.OnboardingResponse;
+import com.shelfeed.backend.domain.member.dto.response.UpdateGenresResponse;
 import com.shelfeed.backend.domain.member.dto.response.UpdateProfileResponse;
 import com.shelfeed.backend.domain.member.dto.response.UserProfileResponse;
 import com.shelfeed.backend.domain.member.service.MemberService;
@@ -38,12 +40,21 @@ public class MemberController {
                 memberService.completeOnboarding(userDetails.getMember().getMemberUserId(), request));
     }
 
+    // 1-1. 관심 장르 설정/수정  PUT /api/v1/users/me/genres
+    @PutMapping("/me/genres")
+    public ApiResponse<UpdateGenresResponse> updateMyGenres(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateGenresRequest request) {
+        return ApiResponse.success(200, "관심 장르가 설정되었습니다.",
+                memberService.updateMyGenres(userDetails.getMember().getMemberUserId(), request));
+    }
+
     // 2. 내 프로필 조회  GET /api/v1/users/me
     @GetMapping("/me")
     public ApiResponse<MyProfileResponse> getMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.success(200,
-                memberService.getMyProfile(userDetails.getMember().getMemberUserId()));
+                memberService.getMyProfile(userDetails.getMember().getMemberUserId())); 
     }
 
     // 3. 프로필 수정  PATCH /api/v1/users/me

--- a/src/main/java/com/shelfeed/backend/domain/member/dto/request/UpdateGenresRequest.java
+++ b/src/main/java/com/shelfeed/backend/domain/member/dto/request/UpdateGenresRequest.java
@@ -1,0 +1,13 @@
+package com.shelfeed.backend.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateGenresRequest {
+    @NotEmpty(message = "최소 1개 이상의 장르를 선택해주세요.")
+    private List<Long> genreIds;
+}
+

--- a/src/main/java/com/shelfeed/backend/domain/member/dto/response/UpdateGenresResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/member/dto/response/UpdateGenresResponse.java
@@ -1,7 +1,6 @@
 package com.shelfeed.backend.domain.member.dto.response;
 
 import com.shelfeed.backend.domain.genre.entity.Genre;
-import com.shelfeed.backend.domain.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,13 +8,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class OnboardingResponse {
-
-    private Long userId;
-    private String nickname;
-    private String profileImageUrl;
-    private String bio;
-    private boolean onboardingCompleted;
+public class UpdateGenresResponse {
     private List<GenreInfo> genres;
 
     @Getter
@@ -32,14 +25,10 @@ public class OnboardingResponse {
         }
     }
 
-    public static OnboardingResponse of(Member member, List<Genre> genres) {
-        return OnboardingResponse.builder()
-                .userId(member.getMemberUserId())
-                .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
-                .bio(member.getBio())
-                .onboardingCompleted(member.isOnboardingCompleted())
+    public static UpdateGenresResponse of(List<Genre> genres) {
+        return UpdateGenresResponse.builder()
                 .genres(genres.stream().map(GenreInfo::of).toList())
                 .build();
     }
 }
+

--- a/src/main/java/com/shelfeed/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/shelfeed/backend/domain/member/service/MemberService.java
@@ -54,8 +54,9 @@ public class MemberService {
             throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
         }
 
-        List<Genre> genres = genreRepository.findAllById(request.getGenreIds());
-        if (genres.size() != request.getGenreIds().size()) {
+        List<Long> requestedGenreIds = request.getGenreIds().stream().distinct().toList();
++       List<Genre> genres = genreRepository.findAllById(requestedGenreIds);
++        if (genres.size() != requestedGenreIds.size()) {
             throw new BusinessException(ErrorCode.GENRE_NOT_FOUND);
         }
 

--- a/src/main/java/com/shelfeed/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/shelfeed/backend/domain/member/service/MemberService.java
@@ -6,10 +6,12 @@ import com.shelfeed.backend.domain.genre.repository.GenreRepository;
 import com.shelfeed.backend.domain.genre.repository.MemberGenreRepository;
 import com.shelfeed.backend.domain.member.dto.request.ChangePasswordRequest;
 import com.shelfeed.backend.domain.member.dto.request.OnboardingRequest;
+import com.shelfeed.backend.domain.member.dto.request.UpdateGenresRequest;
 import com.shelfeed.backend.domain.member.dto.request.UpdateProfileRequest;
 import com.shelfeed.backend.domain.member.dto.request.WithdrawRequest;
 import com.shelfeed.backend.domain.member.dto.response.MyProfileResponse;
 import com.shelfeed.backend.domain.member.dto.response.OnboardingResponse;
+import com.shelfeed.backend.domain.member.dto.response.UpdateGenresResponse;
 import com.shelfeed.backend.domain.member.dto.response.UpdateProfileResponse;
 import com.shelfeed.backend.domain.member.dto.response.UserProfileResponse;
 import com.shelfeed.backend.domain.member.entity.Member;
@@ -72,6 +74,25 @@ public class MemberService {
         member.completeOnboarding();
 
         return OnboardingResponse.of(member, genres);
+    }
+
+    // ── 1-1. 관심 장르 설정/수정
+    public UpdateGenresResponse updateMyGenres(Long memberUserId, UpdateGenresRequest request) {
+        Member member = memberRepository.findByMemberUserId(memberUserId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Genre> genres = genreRepository.findAllById(request.getGenreIds());
+        if (genres.size() != request.getGenreIds().size()) {
+            throw new BusinessException(ErrorCode.GENRE_NOT_FOUND);
+        }
+
+        memberGenreRepository.deleteAllByMember(member);
+        List<MemberGenre> memberGenres = genres.stream()
+                .map(genre -> MemberGenre.create(member, genre))
+                .toList();
+        memberGenreRepository.saveAll(memberGenres);
+
+        return UpdateGenresResponse.of(genres);
     }
 
     // ── 2. 내 프로필 조회


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증된 사용자가 프로필에서 선호 장르를 업데이트할 수 있는 기능(장르 최소 1개 필요)이 추가되었습니다.

* **개선**
  * 장르 업데이트 응답에 선택된 장르 목록이 반환되도록 응답 형식이 추가/개선되었습니다.
  * 온보딩/프로필 응답의 사용자 식별 필드 명칭이 변경되어 응답 구조가 일관성 있게 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->