### PR TITLE
feat(ocr): CLOVA OCR 텍스트 추출 API 엔드포인트 구현

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrApiClient.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrApiClient.java
@@ -18,6 +18,12 @@ import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * Naver CLOVA OCR General V2 API를 호출하는 {@link ClovaOcrClient} 구현체.
+ *
+ * <p>외부 API 타임아웃으로 인한 스레드 풀 고갈을 방지하기 위해
+ * 공유 RestTemplate과 별도로 전용 인스턴스를 생성한다 (connect 5s, read 30s).</p>
+ */
 @Slf4j
 @Component
 public class ClovaOcrApiClient implements ClovaOcrClient {
@@ -38,6 +44,7 @@ public class ClovaOcrApiClient implements ClovaOcrClient {
         this.ocrRestTemplate = new RestTemplate(factory);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<OcrTextField> extractTextFields(String base64Image, String imageFormat) {
         HttpHeaders headers = new HttpHeaders();
@@ -84,7 +91,9 @@ public class ClovaOcrApiClient implements ClovaOcrClient {
                             .build())
                     .collect(Collectors.toList());
 
-        } catch (RestClientException e) {
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
             log.error("CLOVA OCR API 호출 실패", e);
             throw new BusinessException(ErrorCode.OCR_PROCESSING_FAILED, e);
         }

--- a/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrApiClient.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrApiClient.java
@@ -1,0 +1,92 @@
+package com.shelfeed.backend.domain.ocr.client;
+
+import com.shelfeed.backend.domain.ocr.dto.ClovaOcrApiResponse;
+import com.shelfeed.backend.domain.ocr.dto.OcrTextField;
+import com.shelfeed.backend.global.common.exception.BusinessException;
+import com.shelfeed.backend.global.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class ClovaOcrApiClient implements ClovaOcrClient {
+
+    private final RestTemplate ocrRestTemplate;
+    private final String secretKey;
+    private final String apiUrl;
+
+    public ClovaOcrApiClient(
+            @Value("${clova.ocr.secret-key}") String secretKey,
+            @Value("${clova.ocr.api-url}") String apiUrl) {
+        this.secretKey = secretKey;
+        this.apiUrl = apiUrl;
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setReadTimeout(Duration.ofSeconds(30));
+        this.ocrRestTemplate = new RestTemplate(factory);
+    }
+
+    @Override
+    public List<OcrTextField> extractTextFields(String base64Image, String imageFormat) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-OCR-SECRET", secretKey);
+
+        Map<String, Object> image = new HashMap<>();
+        image.put("format", imageFormat);
+        image.put("name", "quote");
+        image.put("data", base64Image);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("version", "V2");
+        body.put("requestId", UUID.randomUUID().toString());
+        body.put("timestamp", System.currentTimeMillis());
+        body.put("images", List.of(image));
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        try {
+            ClovaOcrApiResponse response = ocrRestTemplate.postForObject(apiUrl, request, ClovaOcrApiResponse.class);
+
+            if (response == null || response.getImages() == null || response.getImages().isEmpty()) {
+                throw new BusinessException(ErrorCode.OCR_PROCESSING_FAILED);
+            }
+
+            ClovaOcrApiResponse.ImageResult result = response.getImages().get(0);
+            if (!"SUCCESS".equals(result.getInferResult()) || result.getFields() == null) {
+                throw new BusinessException(ErrorCode.OCR_PROCESSING_FAILED);
+            }
+
+            return result.getFields().stream()
+                    .map(field -> OcrTextField.builder()
+                            .text(field.getInferText())
+                            .lineBreak(field.isLineBreak())
+                            .vertices(field.getBoundingPoly() != null && field.getBoundingPoly().getVertices() != null
+                                    ? field.getBoundingPoly().getVertices().stream()
+                                        .map(v -> OcrTextField.Vertex.builder()
+                                                .x(v.getX() != null ? v.getX() : 0)
+                                                .y(v.getY() != null ? v.getY() : 0)
+                                                .build())
+                                        .collect(Collectors.toList())
+                                    : List.of())
+                            .build())
+                    .collect(Collectors.toList());
+
+        } catch (RestClientException e) {
+            log.error("CLOVA OCR API 호출 실패", e);
+            throw new BusinessException(ErrorCode.OCR_PROCESSING_FAILED, e);
+        }
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrClient.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrClient.java
@@ -1,0 +1,9 @@
+package com.shelfeed.backend.domain.ocr.client;
+
+import com.shelfeed.backend.domain.ocr.dto.OcrTextField;
+
+import java.util.List;
+
+public interface ClovaOcrClient {
+    List<OcrTextField> extractTextFields(String base64Image, String imageFormat);
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrClient.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/client/ClovaOcrClient.java
@@ -4,6 +4,18 @@ import com.shelfeed.backend.domain.ocr.dto.OcrTextField;
 
 import java.util.List;
 
+/**
+ * OCR 외부 API 클라이언트 인터페이스.
+ * 구현체를 교체하여 다른 OCR 서비스로 전환하거나 테스트 시 Mock을 주입할 수 있다.
+ */
 public interface ClovaOcrClient {
+
+    /**
+     * Base64 인코딩된 이미지에서 텍스트 블록을 추출한다.
+     *
+     * @param base64Image Base64 인코딩된 이미지 데이터
+     * @param imageFormat 이미지 형식 (jpg, png, pdf, tiff)
+     * @return 인식된 텍스트 블록 목록 (텍스트 + boundingPoly 좌표 포함)
+     */
     List<OcrTextField> extractTextFields(String base64Image, String imageFormat);
 }

--- a/src/main/java/com/shelfeed/backend/domain/ocr/controller/OcrController.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/controller/OcrController.java
@@ -1,0 +1,26 @@
+package com.shelfeed.backend.domain.ocr.controller;
+
+import com.shelfeed.backend.domain.ocr.dto.OcrExtractRequest;
+import com.shelfeed.backend.domain.ocr.dto.OcrExtractResponse;
+import com.shelfeed.backend.domain.ocr.service.OcrService;
+import com.shelfeed.backend.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OcrController {
+
+    private final OcrService ocrService;
+
+    @PostMapping("/ocr/extract-text")
+    public ApiResponse<OcrExtractResponse> extractText(
+            @Valid @RequestBody OcrExtractRequest request) {
+        return ApiResponse.success(200, ocrService.extractText(request));
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/controller/OcrController.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/controller/OcrController.java
@@ -11,6 +11,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * OCR 텍스트 추출 API 컨트롤러.
+ * 인증된 사용자만 호출 가능하며, SecurityConfig 기본 정책으로 보호된다.
+ */
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -18,6 +22,12 @@ public class OcrController {
 
     private final OcrService ocrService;
 
+    /**
+     * 이미지에서 텍스트를 추출한다.
+     *
+     * @param request Base64 이미지 데이터와 형식
+     * @return 추출된 전체 텍스트와 블록별 좌표 정보
+     */
     @PostMapping("/ocr/extract-text")
     public ApiResponse<OcrExtractResponse> extractText(
             @Valid @RequestBody OcrExtractRequest request) {

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/ClovaOcrApiResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/ClovaOcrApiResponse.java
@@ -6,6 +6,10 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+/**
+ * CLOVA OCR General V2 API 응답 매핑 DTO.
+ * 외부 API 응답 구조를 그대로 매핑하며, 알 수 없는 필드는 무시한다.
+ */
 @Getter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/ClovaOcrApiResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/ClovaOcrApiResponse.java
@@ -1,0 +1,48 @@
+package com.shelfeed.backend.domain.ocr.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClovaOcrApiResponse {
+
+    private List<ImageResult> images;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ImageResult {
+        private String inferResult;
+        private List<Field> fields;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Field {
+        private String inferText;
+        private Float inferConfidence;
+        private boolean lineBreak;
+        private BoundingPoly boundingPoly;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BoundingPoly {
+        private List<VertexPoint> vertices;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class VertexPoint {
+        private Double x;
+        private Double y;
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractRequest.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractRequest.java
@@ -5,6 +5,10 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * OCR 텍스트 추출 요청 DTO.
+ * Base64 인코딩된 이미지 데이터와 형식(jpg, png 등)을 전달받는다.
+ */
 @Getter
 @NoArgsConstructor
 public class OcrExtractRequest {

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractRequest.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractRequest.java
@@ -1,0 +1,18 @@
+package com.shelfeed.backend.domain.ocr.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OcrExtractRequest {
+
+    @NotBlank(message = "이미지 데이터는 필수입니다.")
+    @Size(max = 7_000_000, message = "이미지 데이터는 약 5MB를 초과할 수 없습니다.")
+    private String imageData;
+
+    @NotBlank(message = "이미지 형식은 필수입니다.")
+    private String imageFormat;
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractResponse.java
@@ -1,0 +1,13 @@
+package com.shelfeed.backend.domain.ocr.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OcrExtractResponse {
+    private final String extractedText;
+    private final List<OcrTextField> fields;
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractResponse.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrExtractResponse.java
@@ -5,6 +5,11 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * OCR 텍스트 추출 응답 DTO.
+ * 전체 텍스트(extractedText)와 블록별 좌표 정보(fields)를 포함한다.
+ * 프론트엔드에서 fields의 좌표를 이용해 이미지 위에 텍스트를 오버레이한다.
+ */
 @Getter
 @Builder
 public class OcrExtractResponse {

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrTextField.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrTextField.java
@@ -1,0 +1,21 @@
+package com.shelfeed.backend.domain.ocr.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OcrTextField {
+    private final String text;
+    private final boolean lineBreak;
+    private final List<Vertex> vertices;
+
+    @Getter
+    @Builder
+    public static class Vertex {
+        private final double x;
+        private final double y;
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrTextField.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/dto/OcrTextField.java
@@ -5,6 +5,11 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * OCR 인식 텍스트 블록.
+ * 단일 텍스트 조각과 이미지 내 위치 좌표(vertices)를 담는다.
+ * lineBreak가 true이면 해당 블록 뒤에서 줄바꿈이 발생한다.
+ */
 @Getter
 @Builder
 public class OcrTextField {

--- a/src/main/java/com/shelfeed/backend/domain/ocr/service/OcrService.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/service/OcrService.java
@@ -1,0 +1,46 @@
+package com.shelfeed.backend.domain.ocr.service;
+
+import com.shelfeed.backend.domain.ocr.client.ClovaOcrClient;
+import com.shelfeed.backend.domain.ocr.dto.OcrExtractRequest;
+import com.shelfeed.backend.domain.ocr.dto.OcrExtractResponse;
+import com.shelfeed.backend.domain.ocr.dto.OcrTextField;
+import com.shelfeed.backend.global.common.exception.BusinessException;
+import com.shelfeed.backend.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class OcrService {
+
+    private static final Set<String> SUPPORTED_FORMATS = Set.of("jpg", "jpeg", "png", "pdf", "tiff");
+
+    private final ClovaOcrClient clovaOcrClient;
+
+    public OcrExtractResponse extractText(OcrExtractRequest request) {
+        String format = request.getImageFormat().strip().toLowerCase();
+        if (!SUPPORTED_FORMATS.contains(format)) {
+            throw new BusinessException(ErrorCode.OCR_INVALID_IMAGE);
+        }
+
+        List<OcrTextField> fields = clovaOcrClient.extractTextFields(request.getImageData(), format);
+
+        StringBuilder sb = new StringBuilder();
+        for (OcrTextField field : fields) {
+            sb.append(field.getText());
+            if (field.isLineBreak()) {
+                sb.append("\n");
+            } else {
+                sb.append(" ");
+            }
+        }
+
+        return OcrExtractResponse.builder()
+                .extractedText(sb.toString().trim())
+                .fields(fields)
+                .build();
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/ocr/service/OcrService.java
+++ b/src/main/java/com/shelfeed/backend/domain/ocr/service/OcrService.java
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * OCR 텍스트 추출 서비스.
+ * 이미지 형식 검증, 외부 OCR API 호출, 응답의 lineBreak 기반 텍스트 조합을 담당한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class OcrService {
@@ -20,6 +24,13 @@ public class OcrService {
 
     private final ClovaOcrClient clovaOcrClient;
 
+    /**
+     * Base64 이미지를 OCR 처리하여 텍스트와 좌표를 반환한다.
+     *
+     * @param request 이미지 데이터와 형식을 담은 요청
+     * @return 추출된 전체 텍스트와 블록별 좌표 목록
+     * @throws BusinessException 지원하지 않는 형식이거나 OCR 처리 실패 시
+     */
     public OcrExtractResponse extractText(OcrExtractRequest request) {
         String format = request.getImageFormat().strip().toLowerCase();
         if (!SUPPORTED_FORMATS.contains(format)) {

--- a/src/main/java/com/shelfeed/backend/global/common/exception/BusinessException.java
+++ b/src/main/java/com/shelfeed/backend/global/common/exception/BusinessException.java
@@ -11,4 +11,9 @@ public class BusinessException extends RuntimeException {
         super(errorCode.getMessage());//super : 부모클래스(RuntimeException) 실핼
         this.errorCode = errorCode;
     }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/shelfeed/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/shelfeed/backend/global/common/exception/ErrorCode.java
@@ -86,6 +86,9 @@ public enum ErrorCode {//enum 타입은 public 불가(자동 private) + 객체 �
     ALREADY_BLOCKED(409, "BL002", "이미 차단된 사용자입니다."),
     BLOCK_NOT_FOUND(404, "BL003", "차단 관계를 찾을 수 없습니다."),
     BLOCKED_USER(403, "BL004", "차단된 사용자입니다."),
+    //OCR
+    OCR_PROCESSING_FAILED(502, "O001", "텍스트 추출에 실패했습니다. 잠시 후 다시 시도해주세요."),
+    OCR_INVALID_IMAGE(400, "O002", "지원하지 않는 이미지 형식입니다."),
     ;
 
     private final int status;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,6 +80,11 @@ aladin:
     ttbkey: ${ALADIN_API_KEY}
     version: "20131101"
 
+clova:
+  ocr:
+    secret-key: ${CLOVA_OCR_SECRET_KEY}
+    api-url: ${CLOVA_OCR_API_URL}
+
 admin:
   email: ${ADMIN_EMAIL}
   password: ${ADMIN_PASSWORD}


### PR DESCRIPTION
  ## 📌 PR 요약
  책 페이지 이미지를 CLOVA OCR General V2 API로 처리하여 텍스트와 좌표를 반환하는 `POST /api/v1/ocr/extract-text` 엔드포인트를 추가한다.

  ---

  ## 🎯 변경 목적 / 배경
  감상 작성 시 인용구를 직접 타이핑하는 UX를 개선하기 위해, 책 페이지를 촬영하면 OCR로 텍스트를 추출하는 기능이 필요하다. 프론트엔드에서 boundingPoly 좌표를 활용하여 이미지 위에 텍스트를 오버레이하고, 사용자가 원하는 문장을 탭으로 선택하는 UX를 구현할 예정이며, 이를 위한 백엔드 API이다.

  ---

  ## 🛠️  변경 사항
  - [x] `domain/ocr/` 패키지 신규 생성 (controller, service, client, dto)
  - [x] `POST /api/v1/ocr/extract-text` 엔드포인트 — 인증 필수
  - [x] `ClovaOcrClient` 인터페이스 + `ClovaOcrApiClient` 구현 (기존 AladinClient 패턴)
  - [x] 전용 RestTemplate 생성 (connect 5s, read 30s 타임아웃) — 공유 빈과 분리
  - [x] Base64 페이로드 `@Size(max = 7_000_000)` 제한 (약 5MB) — DoS 방지
  - [x] `BusinessException`에 cause 체인 생성자 추가 — 디버깅 용이성
  - [x] `ErrorCode`에 `OCR_PROCESSING_FAILED(O001)`, `OCR_INVALID_IMAGE(O002)` 추가
  - [x] `application.yml`에 `clova.ocr.secret-key`, `clova.ocr.api-url` 환경변수 설정

  ---

  ## 🔗 관련 이슈
  - Closes #191
  - Related to https://github.com/techeer-project-team-F/FrontEnd_Project/issues/190
  (프론트엔드 OCR 인용구 입력 기능)

  ---

  ## 🧪 테스트 / 검증
  - [ ] 단위 테스트 추가/수정 (`./gradlew test`)
  - [ ] 통합 테스트 통과 (`./gradlew integrationTest` 또는 수동 검증)
  - [x] 로컬 수동 검증 완료
  - [ ] 부하 테스트 (k6) 영향 없음 — 검색/인증 변경 시 필수

  **테스트 결과 / 스크린샷**
  <details>
  <summary>증거 펼치기</summary>

  - IntelliJ Build Project (Ctrl+F9) 컴파일 성공
  - Spring Boot 서버 정상 기동 확인

  </details>

  ---

  ## 📊 영향 범위 (Impact)

  | 항목 | 영향 |
  |------|------|
  | Breaking Change | [x] No |
  | DB 마이그레이션 | [x] No |
  | 환경 변수 변경 | [x] Yes — `CLOVA_OCR_SECRET_KEY`, `CLOVA_OCR_API_URL` 추가 필요 |
  | 외부 API 의존 변화 | [x] Yes — Naver CLOVA OCR General API 신규 의존 |
  | 성능 영향 (P95 변화) | 신규 엔드포인트, 기존 API 영향 없음 |

  ---

  ## ✅ 셀프 체크리스트 (Definition of Done)
  - [x] 코드 컨벤션 / 린트 통과
  - [x] 빌드 성공 (`./gradlew build -x test` 최소)
  - [ ] 테스트 전부 통과
  - [ ] 새로 추가된 public API에 Swagger 문서 반영
  - [x] application*.yml / Secret 변경 시 README 및 운영 노트 갱신
  - [x] 로그/메트릭 누락 없음 (Tempo span, log level 적정)

  ---

  ## ⚠️  리뷰어가 주의 깊게 봐줬으면 하는 부분
  - `ClovaOcrApiClient` 생성자에서 전용 RestTemplate을 직접 생성하는 방식 vs `@Bean`으로 분리하는 방식 — 현재는 OCR 전용이라 클래스 내부에서 생성했으나, 외부 API 클라이언트가 늘어나면 Config 클래스로 분리 검토 필요
  - `BusinessException`에 cause 생성자를 추가했는데, 기존 코드에서 이 생성자를 사용하는 곳은 없으므로 호환성 영향 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지에서 텍스트를 추출하는 OCR API 및 엔드포인트가 추가되었습니다.
  * 추출된 전체 텍스트와 블록별 좌표/메타정보를 포함한 구조화된 응답을 반환합니다.
  * 지원 형식: JPG, JPEG, PNG, PDF, TIFF.

* **예외 처리**
  * OCR 처리 실패와 유효하지 않은 이미지 형식에 대한 명확한 오류 응답 및 원인 포착이 강화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/BackEnd_Project/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->