### PR TITLE
ci(infra): add statuses write permission to PR title validator

### DIFF
--- a/.github/workflows/pr-title-validator.yml
+++ b/.github/workflows/pr-title-validator.yml
@@ -10,6 +10,9 @@ on:
 
 permissions:
   pull-requests: write
+  # wip:true 옵션이 PR에 commit status(pending/success)를 생성하므로 statuses:write 필요.
+  # permissions 블록을 명시하면 미지정 스코프는 none이 되어 status API가 403을 반환함.
+  statuses: write
 
 jobs:
   validate:


### PR DESCRIPTION
## 무엇을
PR 제목 검증 워크플로우(`pr-title-validator.yml`)의 `permissions` 블록에 `statuses: write`를 추가합니다.

## 왜
- 이 워크플로우는 `wip: true` 옵션을 사용하며, 이 옵션은 PR에 commit status(pending/success)를 생성합니다.
- `permissions:` 블록을 명시하면 거기에 없는 스코프는 자동으로 `none`이 됩니다. 기존엔 `pull-requests: write`만 있어 `statuses`가 `none`이었고, status 생성 API가 403(Resource not accessible by integration)을 반환했습니다.

## 비고
워크플로우를 삭제하는 방향으로 결정되어 이 PR은 닫습니다.

참고: amannn/action-semantic-pull-request#233