### PR TITLE
Fix/#198 backend bugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,10 @@ dependencies {
 tasks.withType<Test> {
     useJUnitPlatform()
     jvmArgs("-javaagent:${configurations["mockitoAgent"].asPath}")
+    // Docker Engine v29(Docker Desktop 4.52+, API 1.52)는 docker-java의 기본 협상 API가
+    // 최소 요구치(1.44)보다 낮아 Testcontainers가 /info에서 400으로 실패한다.
+    // api.version을 1.44로 고정해 로컬/CI 모두 최신 Docker에서 Testcontainers가 동작하도록 한다.
+    systemProperty("api.version", "1.44")
 }
 
 // QueryDSL Q클래스 생성 경로

--- a/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
@@ -187,9 +187,17 @@ public class AuthService {
         GoogleTokenResponse tokenResponse = exchangeGoogleCode(request.getCode(), request.getRedirectUri());
         GoogleUserInfo userInfo = getGoogleUserInfo(tokenResponse.accessToken());
 
+        // 이메일이 검증되지 않은 구글 계정(예: Workspace 관리자가 임의 이메일로 만든 계정)은
+        // 그 이메일의 소유를 보장하지 못하므로 거부한다. 미검증 이메일을 그대로 신뢰하면
+        // 동일 이메일의 기존(비밀번호) 계정에 자동 연동되어 계정 탈취/권한 상승이 가능하다.
+        if (!Boolean.TRUE.equals(userInfo.emailVerified())) {
+            throw new BusinessException(ErrorCode.OAUTH_EMAIL_NOT_VERIFIED);
+        }
+
         return socialAccountRepository.findByProviderAndProviderId("GOOGLE", userInfo.sub())
                 .map(socialAccount -> {
                     Member member = socialAccount.getMember();
+                    verifyLoginableStatus(member);
                     member.recordLogin();
                     String accessToken = jwtProvider.generateAccessToken(member);
                     String refreshToken = jwtProvider.generateRefreshToken(member);
@@ -201,23 +209,48 @@ public class AuthService {
                             refreshToken);
                 })
                 .orElseGet(() -> {
-                    // 신규 회원 생성
-                    Long memberUserId = redisService.generateMemberUserId();
-                    String nickname = "Google_" + memberUserId;
-                    Member member = Member.createOAuth(memberUserId, userInfo.email(),
-                            nickname, userInfo.picture());
-                    memberRepository.save(member);
+                    // 이 구글 sub로 연결된 소셜 계정이 없는 경우.
+                    // 같은 이메일로 이미 가입한 회원(이메일 가입 등)이 있으면 새 계정을 만들지 않고
+                    // 그 회원에 SocialAccount만 연결한다(계정 자동 연동). 구글은 이메일 검증
+                    // 제공자라 안전하며, 이를 생략하면 email unique 제약 위반으로 로그인이 실패한다.
+                    boolean[] created = {false};
+                    Member member = memberRepository.findByEmail(userInfo.email())
+                            .map(existing -> {
+                                // 기존 이메일 계정에 자동 연동하기 전 로그인 가능 상태인지 확인
+                                verifyLoginableStatus(existing);
+                                return existing;
+                            })
+                            .orElseGet(() -> {
+                                created[0] = true;
+                                Long memberUserId = redisService.generateMemberUserId();
+                                String nickname = "Google_" + memberUserId;
+                                return memberRepository.save(Member.createOAuth(memberUserId,
+                                        userInfo.email(), nickname, userInfo.picture()));
+                            });
                     socialAccountRepository.save(
                             SocialAccount.create(member, "GOOGLE", userInfo.sub()));
+                    member.recordLogin();
                     String accessToken = jwtProvider.generateAccessToken(member);
                     String refreshToken = jwtProvider.generateRefreshToken(member);
-                    redisService.saveRefreshToken(memberUserId, refreshToken,
+                    redisService.saveRefreshToken(member.getMemberUserId(), refreshToken,
                             jwtProvider.getRefreshTokenExpiresIn());
+                    // 기존 이메일 계정에 연동된 경우 isNewUser=false → 프론트가 onboardingCompleted
+                    // 기준으로 라우팅(온보딩 스킵). 진짜 신규 가입일 때만 true.
                     return new AuthTokenResult.GoogleLogin(
                             GoogleLoginResponse.of(member, accessToken,
-                                    jwtProvider.getAccessTokenExpiresIn(), true),
+                                    jwtProvider.getAccessTokenExpiresIn(), created[0]),
                             refreshToken);
                 });
+    }
+
+    // 로그인 가능 상태 검증 — 탈퇴/정지 계정은 OAuth 로그인도 차단(이메일 로그인 login()과 동일 정책)
+    private void verifyLoginableStatus(Member member) {
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new BusinessException(ErrorCode.WITHDRAWN_MEMBER);
+        }
+        if (member.getStatus() == MemberStatus.SUSPENDED) {
+            throw new BusinessException(ErrorCode.SUSPENDED_MEMBER);
+        }
     }
 
     // Google code → token 교환
@@ -262,6 +295,7 @@ public class AuthService {
     private record GoogleUserInfo(
             String sub,
             String email,
+            @com.fasterxml.jackson.annotation.JsonProperty("email_verified") Boolean emailVerified,
             String name,
             String picture
     ) {}

--- a/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
@@ -148,9 +148,9 @@ public class AuthService {
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);//페스워드 예외 처리
         }
-        if (member.getStatus() == MemberStatus.WITHDRAWN) {
-            throw new BusinessException(ErrorCode.WITHDRAWN_MEMBER);//탈퇴인 예외 처리
-        }
+        // 탈퇴/정지 계정 차단 — 구글 로그인(verifyLoginableStatus)과 동일 정책으로 통일.
+        // 비밀번호 검증 이후에 호출해 계정 상태가 비번 오류와 구분돼 노출되지 않게 한다.
+        verifyLoginableStatus(member);
 
         member.recordLogin();//로그인 시점 기록
 

--- a/src/main/java/com/shelfeed/backend/domain/genre/repository/MemberGenreRepository.java
+++ b/src/main/java/com/shelfeed/backend/domain/genre/repository/MemberGenreRepository.java
@@ -3,6 +3,7 @@ package com.shelfeed.backend.domain.genre.repository;
 import com.shelfeed.backend.domain.genre.entity.MemberGenre;
 import com.shelfeed.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,7 +13,15 @@ import java.util.List;
 //재 온보딩 시 유저의 선호장르 수정
 
 public interface MemberGenreRepository extends JpaRepository<MemberGenre, Long> {
-    void deleteAllByMember(Member member);
+    // 장르 전체 교체 시 delete가 saveAll INSERT보다 먼저 DB에 반영되도록 flush 강제.
+    // (기본 derived delete는 영속성 컨텍스트에 보류되어 INSERT가 먼저 flush되면
+    //  member_genres (member_id, genre_id) 복합 unique 위반 → 409가 발생함)
+    // clearAutomatically는 쓰지 않는다 — completeOnboarding은 이 delete 이후에도 member를
+    // 더 변경(completeOnboarding())하는데, clear로 member가 detach되면 그 변경이 DB에 반영되지
+    // 않는다. 409 해소엔 flush 순서만 보장하면 충분하다.
+    @Modifying(flushAutomatically = true)
+    @Query("delete from MemberGenre mg where mg.member = :member")
+    void deleteAllByMember(@Param("member") Member member);
 
     @Query("""
     SELECT mg FROM MemberGenre mg JOIN FETCH mg.genre WHERE mg.member = :member

--- a/src/main/java/com/shelfeed/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/shelfeed/backend/domain/member/entity/Member.java
@@ -102,10 +102,11 @@ public class Member extends BaseTimeEntity {
     }
 
     // 비즈니스 메서드
-    // 온보딩 전용: null 포함 값 그대로 설정 (초기 정보 주입)
+    // 온보딩 전용: nickname은 필수라 덮어쓰고, bio/이미지는 null이면 기존값 유지.
+    // (가입 시 입력한 소개글이 온보딩에서 bio 미전달(null)로 덮어써져 사라지던 문제 방지)
     public void onboard(String nickname, String bio, String profileImageUrl) {
         this.nickname = nickname;
-        this.bio = bio;
+        if (bio != null) this.bio = bio;
         if (profileImageUrl != null) this.profileImageUrl = profileImageUrl; // OAuth 기본 이미지 보호
     }
     // 프로필 수정 전용: null이면 기존 값 유지 (PATCH 의미)

--- a/src/main/java/com/shelfeed/backend/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/shelfeed/backend/global/common/exception/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {//enum 타입은 public 불가(자동 private) + 객체 �
     INVALID_OAUTH_STATE(400,"A014", "유효하지 않은 OAuth state입니다."),
     OAUTH_PROVIDER_ERROR(502,"A015", "OAuth 제공자 연동 중 오류가 발생했습니다."),
     EMAIL_SEND_FAILED(502,"A016", "이메일 발송에 실패했습니다."),
+    OAUTH_EMAIL_NOT_VERIFIED(403,"A017", "구글 계정의 이메일이 인증되지 않아 로그인할 수 없습니다."),
+    SUSPENDED_MEMBER(403,"A018", "정지된 계정입니다."),
     //도서
     BOOK_NOT_FOUND(404, "B001", "존재하지 않는 도서입니다."),
     //장르

--- a/src/test/java/com/shelfeed/backend/domain/genre/MemberGenreOnboardingIntegrationTest.java
+++ b/src/test/java/com/shelfeed/backend/domain/genre/MemberGenreOnboardingIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.shelfeed.backend.domain.genre;
 
 import com.shelfeed.backend.domain.genre.entity.Genre;
-import com.shelfeed.backend.domain.genre.entity.MemberGenre;
 import com.shelfeed.backend.domain.genre.repository.GenreRepository;
 import com.shelfeed.backend.domain.genre.repository.MemberGenreRepository;
 import com.shelfeed.backend.domain.member.dto.request.OnboardingRequest;
@@ -9,15 +8,22 @@ import com.shelfeed.backend.domain.member.dto.request.UpdateGenresRequest;
 import com.shelfeed.backend.domain.member.entity.Member;
 import com.shelfeed.backend.domain.member.repository.MemberRepository;
 import com.shelfeed.backend.domain.member.service.MemberService;
+import com.shelfeed.backend.global.config.JpaConfig;
+import com.shelfeed.backend.global.jwt.JwtProvider;
 import com.shelfeed.backend.global.redis.RedisService;
 import com.shelfeed.backend.support.TestContainerSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -25,15 +31,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
- * 관심 장르 저장/수정 + 온보딩의 영속성 동작을 실제 DB(Testcontainers)로 검증하는 통합 테스트.
+ * 관심 장르 저장/수정 + 온보딩의 영속성 동작을 실제 DB(Testcontainers MySQL)로 검증한다.
  *
  * Mockito 단위 테스트(MemberServiceGenreTest)는 deleteAllByMember/saveAll의 실제 flush·clear
  * 동작을 재현하지 못해 아래 두 회귀(#198 코드리뷰 발견)를 잡지 못했다. 본 테스트가 그 갭을 메운다:
  *  - HIGH: deleteAllByMember의 clearAutomatically=true가 member를 detach시켜 completeOnboarding()의
  *          onboardingCompleted=true가 DB에 저장되지 않던 회귀
  *  - 409: delete가 saveAll INSERT보다 늦게 flush되어 member_genres 복합 unique 위반
+ *
+ * @DataJpaTest 슬라이스를 쓰는 이유: @SpringBootTest 풀 컨텍스트는 CLOVA/admin 등 외부 시크릿에
+ * 의존하는 빈까지 로드해 CI(시크릿 미설정)에서 컨텍스트 로딩이 실패한다. JPA 슬라이스 + 서비스만
+ * import해 그 의존을 끊는다. JPA 외 의존(Redis/JWT/PasswordEncoder)은 @MockBean으로 대체.
+ *
+ * @Transactional(NOT_SUPPORTED): @DataJpaTest 기본 트랜잭션을 끈다. 켜두면 서비스의 @Transactional이
+ * 테스트 트랜잭션에 합류해 flush/clear 타이밍이 실제 운영과 달라져 회귀를 재현하지 못한다.
+ * 대신 각 테스트가 독립 트랜잭션으로 커밋되므로 @BeforeEach에서 명시적으로 데이터를 비운다.
  */
-@SpringBootTest
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({MemberService.class, JpaConfig.class}) // JpaConfig: @EnableJpaAuditing (created_at 자동 채움) + JPAQueryFactory
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @DisplayName("관심 장르 + 온보딩 영속성 통합 테스트 (#198 회귀)")
 class MemberGenreOnboardingIntegrationTest extends TestContainerSupport {
 
@@ -42,9 +59,10 @@ class MemberGenreOnboardingIntegrationTest extends TestContainerSupport {
     @Autowired GenreRepository genreRepository;
     @Autowired MemberGenreRepository memberGenreRepository;
 
-    // 본 테스트의 검증 대상은 JPA 영속성(detach/flush)이라 Redis는 불필요.
-    // 로컬에 Redis가 없어도 컨텍스트가 뜨도록 mock으로 대체(검증 경로엔 Redis 호출 없음).
+    // MemberService의 비-JPA 의존성. 본 테스트 경로(온보딩/장르 수정)에선 호출되지 않으므로 mock으로 충분.
     @MockBean RedisService redisService;
+    @MockBean JwtProvider jwtProvider;
+    @MockBean PasswordEncoder passwordEncoder;
 
     private Member member;
     private Genre g1;
@@ -53,9 +71,7 @@ class MemberGenreOnboardingIntegrationTest extends TestContainerSupport {
 
     @BeforeEach
     void setUp() {
-        // ddl-auto=create-drop은 클래스당 1회만 스키마를 만들므로 테스트 간 데이터가 남는다.
-        // 각 테스트가 같은 memberUserId/email을 재사용하므로 매 테스트 시작 시 명시적으로 비워 격리한다.
-        // (이 테스트는 flush/detach 동작 검증이 목적이라 @Transactional 롤백 격리는 쓸 수 없음)
+        // NOT_SUPPORTED라 각 테스트가 독립 커밋되어 데이터가 누적된다. 매 테스트 시작 시 명시적으로 비워 격리.
         memberGenreRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
         genreRepository.deleteAllInBatch();

--- a/src/test/java/com/shelfeed/backend/domain/genre/MemberGenreOnboardingIntegrationTest.java
+++ b/src/test/java/com/shelfeed/backend/domain/genre/MemberGenreOnboardingIntegrationTest.java
@@ -1,0 +1,141 @@
+package com.shelfeed.backend.domain.genre;
+
+import com.shelfeed.backend.domain.genre.entity.Genre;
+import com.shelfeed.backend.domain.genre.entity.MemberGenre;
+import com.shelfeed.backend.domain.genre.repository.GenreRepository;
+import com.shelfeed.backend.domain.genre.repository.MemberGenreRepository;
+import com.shelfeed.backend.domain.member.dto.request.OnboardingRequest;
+import com.shelfeed.backend.domain.member.dto.request.UpdateGenresRequest;
+import com.shelfeed.backend.domain.member.entity.Member;
+import com.shelfeed.backend.domain.member.repository.MemberRepository;
+import com.shelfeed.backend.domain.member.service.MemberService;
+import com.shelfeed.backend.global.redis.RedisService;
+import com.shelfeed.backend.support.TestContainerSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 관심 장르 저장/수정 + 온보딩의 영속성 동작을 실제 DB(Testcontainers)로 검증하는 통합 테스트.
+ *
+ * Mockito 단위 테스트(MemberServiceGenreTest)는 deleteAllByMember/saveAll의 실제 flush·clear
+ * 동작을 재현하지 못해 아래 두 회귀(#198 코드리뷰 발견)를 잡지 못했다. 본 테스트가 그 갭을 메운다:
+ *  - HIGH: deleteAllByMember의 clearAutomatically=true가 member를 detach시켜 completeOnboarding()의
+ *          onboardingCompleted=true가 DB에 저장되지 않던 회귀
+ *  - 409: delete가 saveAll INSERT보다 늦게 flush되어 member_genres 복합 unique 위반
+ */
+@SpringBootTest
+@DisplayName("관심 장르 + 온보딩 영속성 통합 테스트 (#198 회귀)")
+class MemberGenreOnboardingIntegrationTest extends TestContainerSupport {
+
+    @Autowired MemberService memberService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired GenreRepository genreRepository;
+    @Autowired MemberGenreRepository memberGenreRepository;
+
+    // 본 테스트의 검증 대상은 JPA 영속성(detach/flush)이라 Redis는 불필요.
+    // 로컬에 Redis가 없어도 컨텍스트가 뜨도록 mock으로 대체(검증 경로엔 Redis 호출 없음).
+    @MockBean RedisService redisService;
+
+    private Member member;
+    private Genre g1;
+    private Genre g2;
+    private Genre g3;
+
+    @BeforeEach
+    void setUp() {
+        // ddl-auto=create-drop은 클래스당 1회만 스키마를 만들므로 테스트 간 데이터가 남는다.
+        // 각 테스트가 같은 memberUserId/email을 재사용하므로 매 테스트 시작 시 명시적으로 비워 격리한다.
+        // (이 테스트는 flush/detach 동작 검증이 목적이라 @Transactional 롤백 격리는 쓸 수 없음)
+        memberGenreRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        genreRepository.deleteAllInBatch();
+
+        // 가입 시 bio 입력한 로컬 회원
+        member = memberRepository.save(
+                Member.createLocal(1001L, "onboard@test.com", "encoded", "초기닉", "가입때 입력한 소개글"));
+        g1 = genreRepository.save(genre("소설"));
+        g2 = genreRepository.save(genre("판타지"));
+        g3 = genreRepository.save(genre("에세이"));
+    }
+
+    @Test
+    @DisplayName("온보딩 완료 후 DB의 onboardingCompleted가 true로 저장된다 (clearAutomatically detach 회귀 방지)")
+    void 온보딩완료_DB영속화() {
+        OnboardingRequest request = onboarding("새닉네임", null, List.of(g1.getGenreId(), g2.getGenreId()));
+
+        memberService.completeOnboarding(member.getMemberUserId(), request);
+
+        // 영속성 컨텍스트가 아닌 DB에서 다시 읽어 검증 (detach된 in-memory 값에 속지 않도록)
+        Member reloaded = memberRepository.findByMemberUserId(member.getMemberUserId()).orElseThrow();
+        assertThat(reloaded.isOnboardingCompleted()).isTrue();
+        assertThat(reloaded.getNickname()).isEqualTo("새닉네임");
+    }
+
+    @Test
+    @DisplayName("온보딩 시 bio 미전달(null)이면 가입 때 입력한 소개글이 유지된다")
+    void 온보딩_bio_null이면_기존값_유지() {
+        OnboardingRequest request = onboarding("새닉네임", null, List.of(g1.getGenreId()));
+
+        memberService.completeOnboarding(member.getMemberUserId(), request);
+
+        Member reloaded = memberRepository.findByMemberUserId(member.getMemberUserId()).orElseThrow();
+        assertThat(reloaded.getBio()).isEqualTo("가입때 입력한 소개글");
+    }
+
+    @Test
+    @DisplayName("관심 장르를 반복 수정해도 409(unique 위반) 없이 전체 교체된다 (flush 순서 회귀 방지)")
+    void 장르_반복수정_멱등() {
+        // 1차: g1, g2
+        memberService.updateMyGenres(member.getMemberUserId(), updateGenres(List.of(g1.getGenreId(), g2.getGenreId())));
+        // 2차: g2, g3 (g2가 겹침 — 기존 행이 안 지워지면 복합 unique 위반)
+        assertThatCode(() ->
+                memberService.updateMyGenres(member.getMemberUserId(), updateGenres(List.of(g2.getGenreId(), g3.getGenreId())))
+        ).doesNotThrowAnyException();
+
+        List<Long> saved = memberGenreRepository.findAllByMemberWithGenre(member).stream()
+                .map(mg -> mg.getGenre().getGenreId())
+                .toList();
+        assertThat(saved).containsExactlyInAnyOrder(g2.getGenreId(), g3.getGenreId());
+    }
+
+    // ── helpers ──────────────────────────────────────────────
+    private Genre genre(String name) {
+        Genre genre = newGenre();
+        ReflectionTestUtils.setField(genre, "genreName", name);
+        return genre;
+    }
+
+    private Genre newGenre() {
+        try {
+            var ctor = Genre.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private OnboardingRequest onboarding(String nickname, String bio, List<Long> genreIds) {
+        OnboardingRequest r = new OnboardingRequest();
+        ReflectionTestUtils.setField(r, "nickname", nickname);
+        ReflectionTestUtils.setField(r, "bio", bio);
+        ReflectionTestUtils.setField(r, "genreIds", genreIds);
+        return r;
+    }
+
+    private UpdateGenresRequest updateGenres(List<Long> genreIds) {
+        UpdateGenresRequest r = new UpdateGenresRequest();
+        ReflectionTestUtils.setField(r, "genreIds", genreIds);
+        return r;
+    }
+}

--- a/src/test/java/com/shelfeed/backend/domain/genre/MemberGenreOnboardingIntegrationTest.java
+++ b/src/test/java/com/shelfeed/backend/domain/genre/MemberGenreOnboardingIntegrationTest.java
@@ -76,9 +76,10 @@ class MemberGenreOnboardingIntegrationTest extends TestContainerSupport {
         memberRepository.deleteAllInBatch();
         genreRepository.deleteAllInBatch();
 
-        // 가입 시 bio 입력한 로컬 회원
-        member = memberRepository.save(
-                Member.createLocal(1001L, "onboard@test.com", "encoded", "초기닉", "가입때 입력한 소개글"));
+        // 가입 시 bio + 프로필 이미지를 가진 로컬 회원 (온보딩 시 bio/이미지 보존 검증용)
+        Member m = Member.createLocal(1001L, "onboard@test.com", "encoded", "초기닉", "가입때 입력한 소개글");
+        m.updateProfile(null, null, "https://img.example/origin.png"); // null-safe: 이미지만 설정
+        member = memberRepository.save(m);
         g1 = genreRepository.save(genre("소설"));
         g2 = genreRepository.save(genre("판타지"));
         g3 = genreRepository.save(genre("에세이"));
@@ -98,14 +99,16 @@ class MemberGenreOnboardingIntegrationTest extends TestContainerSupport {
     }
 
     @Test
-    @DisplayName("온보딩 시 bio 미전달(null)이면 가입 때 입력한 소개글이 유지된다")
+    @DisplayName("온보딩 시 bio·프로필이미지 미전달(null)이면 가입 때 값이 유지된다")
     void 온보딩_bio_null이면_기존값_유지() {
+        // onboarding 요청에 bio·profileImageUrl 모두 null — Member.onboard()가 null이면 기존값 유지해야 함
         OnboardingRequest request = onboarding("새닉네임", null, List.of(g1.getGenreId()));
 
         memberService.completeOnboarding(member.getMemberUserId(), request);
 
         Member reloaded = memberRepository.findByMemberUserId(member.getMemberUserId()).orElseThrow();
         assertThat(reloaded.getBio()).isEqualTo("가입때 입력한 소개글");
+        assertThat(reloaded.getProfileImageUrl()).isEqualTo("https://img.example/origin.png");
     }
 
     @Test


### PR DESCRIPTION
  ## 변경 사항
  프론트 연동 테스트에서 발견된 인증/회원 버그 3건 수정 + 회귀 통합 테스트.

  - **온보딩 bio 소실**: `Member.onboard()` null-safe
  - **관심 장르 수정 409**: `deleteAllByMember`에 `@Modifying(flushAutomatically=true)` (flush 순서)
  - **구글 OAuth 동일 이메일 실패 + 보안**: 이메일 자동 연동 + `email_verified` 검증 + 탈퇴/정지 상태 검증
  - **회귀 테스트**: 실DB(Testcontainers) 통합 테스트 3건, build.gradle Docker v29 호환

  ## 배경
  - bio: 온보딩이 bio 미전달(null)인데 무조건 덮어써 소실
  - 장르 409: deleteAll은 있었으나 Hibernate가 INSERT를 DELETE보다 먼저 flush → 복합 unique 위반
  - OAuth: 같은 이메일 이메일가입+구글로그인 시 email unique 위반 실패. 단순 연동은 미검증 이메일로 계정 탈취 위험이 있어 email_verified·상태 검증 동반

  ## 코드 리뷰 반영
  초기 수정 후 다중 에이전트 리뷰에서 발견:
  - **CRITICAL**: 미검증 이메일 자동연동 → 계정 탈취/권한 상승 → email_verified 검증으로 방어
  - **HIGH**: `clearAutomatically=true`가 온보딩 `onboardingCompleted` 저장을 막는 회귀 → 제거 + 통합 테스트로 검증

  ## 검증
  - 전체 테스트 63개 통과 (failures 0)

  Closes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * OAuth 로그인 시 이메일 인증 여부를 필수로 확인하도록 강화했습니다.
  * 소셜 계정 연동 시 기존 회원 계정과의 통합 처리를 개선했습니다.
  * 정지된 계정의 로그인을 차단하는 정책을 통일했습니다.

* **Tests**
  * 온보딩 및 관심 장르 저장 로직에 대한 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->