### PR TITLE
fix: P0 보안/안정성 핫픽스 - JWT 토큰 타입 분리, CORS 강화, 타임아웃, 이메일 비동기화, SSM 도입

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     // Spring Cloud AWS 3.x (S3 - Presigned URL)
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1")
 
+    // Spring Cloud AWS 3.x (SSM Parameter Store - 시크릿 관리)
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.2.1")
+
     // Prometheus 메트릭
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,0 +1,1105 @@
+# Shelfeed REST API 명세서
+
+> **출처(기준): 실제 백엔드 코드** (`BackEnd_Project`, Spring Boot 3.4 / Java 21) — 코드에서 자동 추출·검증.
+> 작성일: 2026-06-10 · 총 **64개 엔드포인트** / 14개 컨트롤러.
+
+## 공통 규약
+
+- **Base URL**: `/api/v1`
+- **응답 봉투**: 모든 응답은 `ApiResponse<T>`로 감쌈 — `{ "status": "SUCCESS|ERROR", "code": <httpStatus>, "message": <string?>, "data": <T> }` (null 필드는 직렬화 제외).
+- **인증**: `Authorization: Bearer <accessToken>` 헤더. 리프레시 토큰은 httpOnly 쿠키. 토큰에는 `type`(access/refresh) 클레임 포함 — access 토큰만 인증에 사용 가능.
+- **인증 구분**: `공개`(permitAll) / `인증 필요`(로그인) / `ADMIN`(관리자). 일부 GET은 비로그인 허용이되 로그인 시 개인화 필드(isFollowing/isLiked 등) 채워짐.
+- **페이지네이션**: 커서 기반. 대부분 `cursor`(Long PK) + `limit`(default 20), 도서리뷰 정렬은 `cursorLike`/`cursorRating` 추가, 알림은 opaque `String cursor`. 목록 응답은 `hasNext`/`nextCursor` 포함.
+- **에러**: `status:"ERROR"`, `code`=HTTP 상태, `message`=사유. (참고: 일부 엔드포인트는 비즈니스 에러코드 미노출 — 개선 계획 BE-14 참조)
+
+---
+
+## 1. 인증 · 회원 · 관리자 (Auth / Member / Admin)
+
+### POST /api/v1/auth/signup
+- 목적: 이메일 회원가입
+- 인증: 공개 (permitAll)
+- 파라미터: 없음
+- 요청 (SignupRequest):
+  - `email` (string, 필수) — @NotBlank, @Email
+  - `password` (string, 필수) — @NotBlank, @Pattern `^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$` (8자 이상, 영문+숫자+특수문자)
+  - `nickname` (string, 필수) — @NotBlank, @Size(min=2, max=50)
+  - `bio` (string, 선택) — @Size(max=300)
+- 응답 (SignupResponse):
+  - `accessToken` (string)
+  - `accessTokenExpiresIn` (number, long, 초 단위)
+  - `user` (object):
+    - `userId` (number, Long)
+    - `email` (string)
+    - `nickname` (string)
+    - `bio` (string)
+    - `emailVerified` (boolean)
+- 성공 상태: **201 Created** (refreshToken은 `refreshToken` 쿠키로 설정, path=/api/v1/auth, HttpOnly, Secure, SameSite=Strict)
+
+### POST /api/v1/auth/email/verify
+- 목적: 이메일 인증코드 확인
+- 인증: 공개 (permitAll, `/api/v1/auth/email/**`)
+- 파라미터: 없음
+- 요청 (EmailVerifyRequest):
+  - `email` (string, 필수) — @NotBlank, @Email
+  - `code` (string, 필수) — @NotBlank, @Pattern `^\d{6}$` (6자리 숫자)
+- 응답 (EmailVerifyResponse):
+  - `email` (string)
+  - `emailVerified` (boolean)
+- 성공 상태: 200
+
+### POST /api/v1/auth/email/resend
+- 목적: 이메일 인증 코드 재발송
+- 인증: 공개 (permitAll, `/api/v1/auth/email/**`)
+- 파라미터: 없음
+- 요청 (EmailResendRequest):
+  - `email` (string, 필수) — @NotBlank, @Email
+- 응답: `Void` (`data` = null)
+- 성공 상태: 200
+
+### POST /api/v1/auth/login
+- 목적: 이메일 로그인
+- 인증: 공개 (permitAll)
+- 파라미터: 없음
+- 요청 (LoginRequest):
+  - `email` (string, 필수) — @NotBlank, @Email
+  - `password` (string, 필수) — @NotBlank
+- 응답 (LoginResponse):
+  - `accessToken` (string)
+  - `accessTokenExpiresIn` (number, Long)
+  - `user` (object):
+    - `userId` (number, Long)
+    - `email` (string)
+    - `nickname` (string)
+    - `profileImageUrl` (string)
+    - `bio` (string)
+    - `emailVerified` (boolean)
+    - `onboardingCompleted` (boolean)
+- 성공 상태: 200 (refreshToken 쿠키 설정)
+
+### GET /api/v1/auth/oauth2/google
+- 목적: Google OAuth 로그인 URL 발급
+- 인증: 공개 (permitAll, `/api/v1/auth/oauth2/**`)
+- 파라미터: 없음
+- 요청: 없음
+- 응답 (OAuthLoginUrlResponse):
+  - `loginUrl` (string)
+- 성공 상태: 200
+
+### POST /api/v1/auth/oauth2/google/login
+- 목적: Google OAuth 로그인 완료(코드 교환)
+- 인증: 공개 (permitAll, `/api/v1/auth/oauth2/**`)
+- 파라미터: 없음
+- 요청 (OAuthTokenRequest):
+  - `code` (string, 필수) — @NotBlank
+  - `redirectUri` (string, 필수) — @NotBlank
+  - `state` (string, 필수) — @NotBlank
+- 응답 (GoogleLoginResponse):
+  - `accessToken` (string)
+  - `accessTokenExpiresIn` (number, Long)
+  - `isNewUser` (boolean) — JSON 키 `isNewUser`
+  - `user` (object):
+    - `userId` (number, Long)
+    - `email` (string)
+    - `nickname` (string)
+    - `profileImageUrl` (string)
+    - `emailVerified` (boolean)
+    - `onboardingCompleted` (boolean)
+- 성공 상태: 200 (refreshToken 쿠키 설정)
+
+### POST /api/v1/auth/token/refresh
+- 목적: 액세스 토큰 갱신
+- 인증: 공개 (permitAll) — 단, `refreshToken` 쿠키 필요
+- 파라미터:
+  - `refreshToken` (cookie, string, 선택; required=false) — 갱신 대상 리프레시 토큰
+- 요청 본문: 없음
+- 응답 (TokenRefreshResponse):
+  - `accessToken` (string)
+  - `accessTokenExpiresIn` (number, Long)
+- 성공 상태: 200 (새 refreshToken 쿠키 재설정)
+
+### POST /api/v1/auth/logout
+- 목적: 로그아웃 (액세스 토큰 블랙리스트 + 리프레시 토큰 폐기)
+- 인증: 인증 필요 (PERMIT_ALL/GET_PERMIT_ALL에 없으므로 `anyRequest().authenticated()`)
+- 파라미터:
+  - `Authorization` (header, string, 필수) — `Bearer {accessToken}` 형식. 없거나 형식 불일치 시 INVALID_TOKEN 예외
+  - `refreshToken` (cookie, string, 선택; required=false)
+- 요청 본문: 없음
+- 응답: `Void` (`data` = null)
+- 성공 상태: 200 (refreshToken 쿠키 삭제 maxAge=0)
+
+### POST /api/v1/auth/password/reset-request
+- 목적: 비밀번호 재설정 이메일 요청
+- 인증: 공개 (permitAll, `/api/v1/auth/password/**`)
+- 파라미터: 없음
+- 요청 (PasswordResetSendRequest):
+  - `email` (string, 필수) — @NotBlank, @Email
+- 응답: `Void` (`data` = null)
+- 성공 상태: 200
+
+### POST /api/v1/auth/password/reset
+- 목적: 비밀번호 재설정(토큰 검증 후 변경)
+- 인증: 공개 (permitAll, `/api/v1/auth/password/**`)
+- 파라미터: 없음
+- 요청 (PasswordResetRequest):
+  - `token` (string, 필수) — @NotBlank
+  - `newPassword` (string, 필수) — @NotBlank, @Pattern `^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$`
+- 응답: `Void` (`data` = null)
+- 성공 상태: 200
+
+### GET /api/v1/auth/check-nickname
+- 목적: 닉네임 중복 확인
+- 인증: 공개 (permitAll)
+- 파라미터:
+  - `nickname` (query, string, 필수) — @RequestParam, 기본값 없음
+- 요청 본문: 없음
+- 응답 (AvailableResponse):
+  - `available` (boolean)
+- 성공 상태: 200
+
+### GET /api/v1/auth/check-email
+- 목적: 이메일 중복 확인
+- 인증: 공개 (permitAll)
+- 파라미터:
+  - `email` (query, string, 필수) — @RequestParam, 기본값 없음
+- 요청 본문: 없음
+- 응답 (AvailableResponse):
+  - `available` (boolean)
+- 성공 상태: 200
+
+---
+
+## Member / Users (`/api/v1/users`)
+
+### POST /api/v1/users/me/onboarding
+- 목적: 온보딩 완료(프로필 + 관심 장르 설정)
+- 인증: 인증 필요 (`anyRequest().authenticated()`; `@AuthenticationPrincipal` 사용)
+- 파라미터: 없음
+- 요청 (OnboardingRequest):
+  - `nickname` (string, 필수) — @NotBlank, @Size(max=50)
+  - `profileImageUrl` (string, 선택) — 검증 없음
+  - `bio` (string, 선택) — @Size(max=300)
+  - `genreIds` (array of number/Long, 필수) — @NotEmpty (최소 1개)
+- 응답 (OnboardingResponse):
+  - `userId` (number, Long)
+  - `nickname` (string)
+  - `profileImageUrl` (string)
+  - `bio` (string)
+  - `onboardingCompleted` (boolean)
+  - `genres` (array of object):
+    - `genreId` (number, Long)
+    - `name` (string)
+- 성공 상태: **201 Created** (`@ResponseStatus(HttpStatus.CREATED)`)
+
+### PUT /api/v1/users/me/genres
+- 목적: 관심 장르 설정/수정
+- 인증: 인증 필요
+- 파라미터: 없음
+- 요청 (UpdateGenresRequest):
+  - `genreIds` (array of number/Long, 필수) — @NotEmpty (최소 1개)
+- 응답 (UpdateGenresResponse):
+  - `genres` (array of object):
+    - `genreId` (number, Long)
+    - `name` (string)
+- 성공 상태: 200
+
+### GET /api/v1/users/me
+- 목적: 내 프로필 조회
+- 인증: 인증 필요 (`/api/v1/users/me`는 GET_PERMIT_ALL의 `{userId}` 패턴에 매칭되지 않으므로 인증 필요)
+- 파라미터: 없음
+- 요청 본문: 없음
+- 응답 (MyProfileResponse):
+  - `userId` (number, Long)
+  - `email` (string)
+  - `nickname` (string)
+  - `profileImageUrl` (string)
+  - `bio` (string)
+  - `libraryVisibility` (string enum: PUBLIC | PRIVATE)
+  - `emailVerified` (boolean)
+  - `onboardingCompleted` (boolean)
+  - `followerCount` (number, int)
+  - `followingCount` (number, int)
+  - `reviewCount` (number, int)
+  - `genres` (array of object):
+    - `genreId` (number, Long)
+    - `name` (string)
+- 성공 상태: 200
+
+### PATCH /api/v1/users/me
+- 목적: 내 프로필 수정
+- 인증: 인증 필요
+- 파라미터: 없음
+- 요청 (UpdateProfileRequest) — 모든 필드 선택(부분 수정):
+  - `nickname` (string, 선택) — @Size(max=50)
+  - `profileImageUrl` (string, 선택) — 검증 없음
+  - `bio` (string, 선택) — @Size(max=300)
+- 응답 (UpdateProfileResponse):
+  - `userId` (number, Long)
+  - `nickname` (string)
+  - `profileImageUrl` (string)
+  - `bio` (string)
+  - `libraryVisibility` (string enum: PUBLIC | PRIVATE)
+- 성공 상태: 200
+
+### GET /api/v1/users/{userId}
+- 목적: 타 유저 프로필 조회
+- 인증: 공개 (GET_PERMIT_ALL의 `/api/v1/users/{userId}`; 로그인 시 인증 정보로 팔로우 여부 채움, 비로그인 허용)
+- 파라미터:
+  - `userId` (path, number/Long, 필수) — @PathVariable
+- 요청 본문: 없음
+- 응답 (UserProfileResponse):
+  - `userId` (number, Long)
+  - `nickname` (string)
+  - `profileImageUrl` (string)
+  - `bio` (string)
+  - `libraryVisibility` (string enum: PUBLIC | PRIVATE)
+  - `followerCount` (number, int)
+  - `followingCount` (number, int)
+  - `reviewCount` (number, int)
+  - `isFollowing` (boolean) — JSON 키 `isFollowing`
+  - `isFollowedBy` (boolean) — JSON 키 `isFollowedBy`
+- 성공 상태: 200
+
+### PUT /api/v1/users/me/password
+- 목적: 비밀번호 변경
+- 인증: 인증 필요
+- 파라미터: 없음
+- 요청 (ChangePasswordRequest):
+  - `currentPassword` (string, 필수) — @NotBlank
+  - `newPassword` (string, 필수) — @NotBlank, @Pattern `^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$`
+- 응답: `Void` (`data` = null)
+- 성공 상태: 200 (변경 후 새 refreshToken 쿠키 재설정)
+
+### GET /api/v1/users/me/settings
+- 목적: 알림/공개범위 설정 조회
+- 인증: 인증 필요
+- 파라미터: 없음
+- 요청 본문: 없음
+- 응답 (SettingsResponse):
+  - `likeEnabled` (boolean)
+  - `commentEnabled` (boolean)
+  - `followEnabled` (boolean)
+  - `followingReviewEnabled` (boolean)
+  - `libraryVisibility` (string enum: PUBLIC | PRIVATE)
+- 성공 상태: 200
+
+### PATCH /api/v1/users/me/settings
+- 목적: 알림/공개범위 설정 수정
+- 인증: 인증 필요
+- 파라미터: 없음
+- 요청 (SettingsUpdateRequest) — 모든 필드 선택(부분 수정, 검증 없음):
+  - `likeEnabled` (boolean, nullable)
+  - `commentEnabled` (boolean, nullable)
+  - `followEnabled` (boolean, nullable)
+  - `followingReviewEnabled` (boolean, nullable)
+  - `libraryVisibility` (string enum: PUBLIC | PRIVATE, nullable)
+- 응답 (SettingsResponse):
+  - `likeEnabled` (boolean)
+  - `commentEnabled` (boolean)
+  - `followEnabled` (boolean)
+  - `followingReviewEnabled` (boolean)
+  - `libraryVisibility` (string enum: PUBLIC | PRIVATE)
+- 성공 상태: 200
+
+### DELETE /api/v1/users/me
+- 목적: 회원 탈퇴
+- 인증: 인증 필요
+- 파라미터:
+  - `Authorization` (header, string, 선택; required=false) — `Bearer {accessToken}` 형식 필요. 없거나 형식 불일치 시 INVALID_TOKEN 예외
+- 요청 (WithdrawRequest):
+  - `password` (string, 선택) — @Size(max=100)
+  - `reason` (string, 선택) — @Size(max=500)
+- 응답: `Void` (`data` = null)
+- 성공 상태: 200 (refreshToken 쿠키 삭제 maxAge=0)
+
+---
+
+## Admin (`/api/v1/admin`)
+
+클래스 레벨 `@PreAuthorize("hasRole('ADMIN')")` + SecurityConfig `/api/v1/admin/**` → `hasRole("ADMIN")`.
+
+### GET /api/v1/admin/dashboard
+- 목적: 관리자 대시보드 통계 조회
+- 인증: **ADMIN** (ROLE_ADMIN 필요)
+- 파라미터: 없음
+- 요청 본문: 없음
+- 응답 (AdminDashboardResponse):
+  - `totalMembers` (number, long)
+  - `pendingReports` (number, long)
+  - `totalReports` (number, long)
+- 성공 상태: 200
+
+---
+
+## 2. 도서 · 감상 · 서재 (Book / Review / Library)
+
+### GET /api/v1/books/search
+
+- **목적**: 도서 검색 (알라딘 API 연동, 커서 페이지네이션)
+- **인증**: 공개 (로그인 시 `inMyLibrary` 반영 — 선택적 인증)
+- **파라미터** (query, `@ModelAttribute BookSearchRequest`):
+  - `query` (String, 선택 — 코드상 검증 없음, 주석상 검색어): 검색어
+  - `limit` (int, 선택, 기본값 `20`, Swagger 제약 min 1 / max 50): 조회 개수
+  - `page` (int, 선택, 기본값 `1`, Swagger 제약 min 1): 알라딘 API 페이지 번호
+- **요청 본문**: 없음
+- **응답** (`BookSearchListResponse`):
+  - `content` (array of `BookSummaryResponse`):
+    - `bookId` (Long)
+    - `isbn13` (String)
+    - `title` (String)
+    - `author` (String)
+    - `publisher` (String)
+    - `coverImageUrl` (String)
+    - `publishedDate` (LocalDate, `yyyy-MM-dd`)
+    - `inMyLibrary` (Boolean)
+  - `nextCursor` (Long, nullable — 마지막 항목의 bookId, hasNext=false면 null)
+  - `hasNext` (boolean)
+  - `size` (int)
+- **성공 상태**: 200
+
+### GET /api/v1/books/{bookId}
+
+- **목적**: 도서 상세 조회 (평점/리뷰수/내 서재·리뷰 상태 포함)
+- **인증**: 공개 (로그인 시 `myLibraryStatus`/`myLibraryBookId`/`myReviewId` 반영 — 선택적 인증)
+- **파라미터**:
+  - `bookId` (Long, path, 필수)
+- **요청 본문**: 없음
+- **응답** (`BookDetailResponse`, 상세조회용 `of(...)`):
+  - `bookId` (Long)
+  - `isbn13` (String)
+  - `title` (String)
+  - `author` (String)
+  - `publisher` (String)
+  - `coverImageUrl` (String)
+  - `description` (String)
+  - `totalPages` (Integer)
+  - `publishedDate` (LocalDate, `yyyy-MM-dd`)
+  - `aladinItemId` (String)
+  - `averageRating` (Double)
+  - `reviewCount` (Long)
+  - `myLibraryStatus` (String — ReadingStatus 이름, nullable)
+  - `myLibraryBookId` (Long, nullable)
+  - `myReviewId` (Long, nullable)
+  - (참고: `inMyLibrary` 필드는 이 응답에서는 미설정 → null 이므로 JSON 제외)
+- **성공 상태**: 200
+
+### GET /api/v1/books/isbn/{isbn13}
+
+- **목적**: ISBN13으로 도서 조회
+- **인증**: 공개 (로그인 시 `inMyLibrary` 반영 — 선택적 인증)
+- **파라미터**:
+  - `isbn13` (String, path, 필수)
+- **요청 본문**: 없음
+- **응답** (`BookDetailResponse`, ISBN용 `ofIsbn(...)`):
+  - `bookId` (Long)
+  - `isbn13` (String)
+  - `title` (String)
+  - `author` (String)
+  - `publisher` (String)
+  - `coverImageUrl` (String)
+  - `description` (String)
+  - `totalPages` (Integer)
+  - `publishedDate` (LocalDate, `yyyy-MM-dd`)
+  - `aladinItemId` (String)
+  - `inMyLibrary` (Boolean)
+  - (참고: `averageRating`, `reviewCount`, `myLibraryStatus`, `myLibraryBookId`, `myReviewId` 는 미설정 → null 이므로 JSON 제외)
+- **성공 상태**: 200
+
+### GET /api/v1/books/{bookId}/reviews
+
+- **목적**: 특정 도서의 감상 목록 조회 (정렬/커서 페이지네이션)
+- **인증**: 공개 (로그인 시 각 항목 `isLiked` 반영 — 선택적 인증)
+- **파라미터**:
+  - `bookId` (Long, path, 필수)
+  - query (`@ModelAttribute BookReviewSearchRequest`):
+    - `sort` (String, 선택, 기본값 `latest`, 허용값 `latest`/`popular`/`rating_high`/`rating_low`)
+    - `cursor` (Long, nullable): 페이지네이션 커서 — `latest`/`popular`: 직전 마지막 reviewId, `rating_*`: 직전 마지막 reviewId
+    - `cursorRating` (Integer, nullable): 평점순 전용 커서 — 직전 마지막 항목의 rating (`rating_high`/`rating_low` 에서만 사용)
+    - `cursorLike` (Integer, nullable): 인기순 전용 커서 — 직전 마지막 항목의 likeCount (`popular` 에서만 사용)
+    - `limit` (int, 선택, 기본값 `20`, Swagger 제약 min 1 / max 50)
+- **요청 본문**: 없음
+- **응답** (`BookReviewListResponse`):
+  - `content` (array of `BookReviewResponse`):
+    - `reviewId` (Long)
+    - `user` (object `UserInfo`):
+      - `userId` (Long)
+      - `nickname` (String)
+      - `profileImageUrl` (String)
+    - `rating` (int)
+    - `content` (String)
+    - `quote` (String)
+    - `isSpoiler` (Boolean)
+    - `likeCount` (int)
+    - `commentCount` (int)
+    - `isLiked` (Boolean)
+    - `createdAt` (LocalDateTime, ISO-8601)
+  - `nextCursor` (Long, nullable — 마지막 항목 reviewId)
+  - `nextCursorRating` (Integer, nullable — `rating_*` 정렬 시에만 채워짐, 마지막 항목 rating)
+  - `nextCursorLike` (Integer, nullable — `popular` 정렬 시에만 채워짐, 마지막 항목 likeCount)
+  - `hasNext` (boolean)
+  - `size` (int)
+- **성공 상태**: 200
+
+---
+
+## Review 도메인 (`/api/v1`, base path 분산)
+
+### POST /api/v1/reviews
+
+- **목적**: 감상(리뷰) 작성
+- **인증**: 인증 필요 (`anyRequest().authenticated()`; 컨트롤러가 `userDetails.getMember()` 직접 호출)
+- **파라미터**: 없음
+- **요청 본문** (`ReviewCreateRequest`, `@Valid`):
+  - `bookId` (Long, 필수 — `@NotNull` "도서 ID는 필수입니다.")
+  - `libraryBookId` (Long, 선택)
+  - `rating` (Byte, 필수 — `@NotNull`, `@Min(1)`/`@Max(5)` "평점은 1~5 사이여야 합니다.")
+  - `content` (String, 선택)
+  - `quote` (String, 선택)
+  - `readPages` (Integer, 선택)
+  - `isSpoiler` (boolean, 선택, JSON 키 `isSpoiler`)
+  - `reviewVisibility` (ReviewVisibility enum, 필수 — `@NotNull` "공개 범위는 필수입니다.")
+  - `reviewStatus` (ReviewStatus enum, 필수 — `@NotNull` "감상 상태는 필수입니다.")
+  - `tags` (array of String, 선택 — `@Size(max=5)` "태그는 최대 5개까지 등록할 수 있습니다.")
+- **응답** (`ReviewCreateResponse`):
+  - `reviewId` (Long)
+  - `bookId` (Long)
+  - `rating` (byte)
+  - `content` (String)
+  - `quote` (String)
+  - `readPages` (Integer)
+  - `isSpoiler` (boolean, JSON 키 `isSpoiler`)
+  - `reviewVisibility` (ReviewVisibility)
+  - `reviewStatus` (ReviewStatus)
+  - `likeCount` (int)
+  - `commentCount` (int)
+  - `tags` (array of String)
+  - `createdAt` (LocalDateTime)
+- **성공 상태**: **201 Created** (`@ResponseStatus(CREATED)`, message "감상이 작성되었습니다.")
+
+### GET /api/v1/reviews/{reviewId}
+
+- **목적**: 감상 상세 조회
+- **인증**: 공개 (GET_PERMIT_ALL에 `/api/v1/reviews/{reviewId}` 포함; 로그인 시 `isMine`/`isLiked` 반영 — 선택적 인증)
+- **파라미터**:
+  - `reviewId` (Long, path, 필수)
+- **요청 본문**: 없음
+- **응답** (`ReviewDetailResponse`):
+  - `reviewId` (Long)
+  - `user` (object `UserInfo`): `userId` (Long), `nickname` (String), `profileImageUrl` (String)
+  - `book` (object `BookInfo`): `bookId` (Long), `isbn13` (String), `title` (String), `author` (String), `coverImageUrl` (String)
+  - `rating` (byte)
+  - `content` (String)
+  - `quote` (String)
+  - `readPages` (Integer)
+  - `isSpoiler` (boolean, JSON 키 `isSpoiler`)
+  - `reviewVisibility` (ReviewVisibility)
+  - `reviewStatus` (ReviewStatus)
+  - `likeCount` (int)
+  - `commentCount` (int)
+  - `isLiked` (boolean, JSON 키 `isLiked`)
+  - `isMine` (boolean, JSON 키 `isMine`)
+  - `tags` (array of String)
+  - `createdAt` (LocalDateTime)
+  - `updatedAt` (LocalDateTime)
+- **성공 상태**: 200
+
+### PUT /api/v1/reviews/{reviewId}
+
+- **목적**: 감상 수정
+- **인증**: 인증 필요 (PUT은 permitAll 목록에 없음; `anyRequest().authenticated()`)
+- **파라미터**:
+  - `reviewId` (Long, path, 필수)
+- **요청 본문** (`ReviewUpdateRequest`, `@Valid`):
+  - `rating` (Byte, 필수 — `@NotNull`, `@Min(1)`/`@Max(5)`)
+  - `content` (String, 선택)
+  - `quote` (String, 선택)
+  - `readPages` (Integer, 선택)
+  - `isSpoiler` (boolean, 선택, JSON 키 `isSpoiler`)
+  - `reviewVisibility` (ReviewVisibility enum, 필수 — `@NotNull`)
+  - `reviewStatus` (ReviewStatus enum, 필수 — `@NotNull`)
+  - `tags` (array of String, 선택 — `@Size(max=5)`)
+- **응답** (`ReviewUpdateResponse`):
+  - `reviewId` (Long)
+  - `rating` (byte)
+  - `content` (String)
+  - `quote` (String)
+  - `readPages` (Integer)
+  - `isSpoiler` (boolean, JSON 키 `isSpoiler`)
+  - `reviewVisibility` (ReviewVisibility)
+  - `reviewStatus` (ReviewStatus)
+  - `tags` (array of String)
+  - `updatedAt` (LocalDateTime)
+- **성공 상태**: 200 (message "감상이 수정되었습니다.")
+
+### DELETE /api/v1/reviews/{reviewId}
+
+- **목적**: 감상 삭제
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터**:
+  - `reviewId` (Long, path, 필수)
+- **요청 본문**: 없음
+- **응답**: `data` 없음 (`Void`) — message만 반환
+- **성공 상태**: 200 (message "감상이 삭제되었습니다.")
+
+### GET /api/v1/reviews/me
+
+- **목적**: 내 감상 목록 조회 (상태 필터 + 커서 페이지네이션)
+- **인증**: 인증 필요 (SecurityConfig에서 명시적으로 `GET /api/v1/reviews/me` → `authenticated()`; `{reviewId}` 와일드카드 매칭 방지)
+- **파라미터** (query):
+  - `status` (ReviewStatus enum, 선택, `required=false` — `DRAFT`/`PUBLISHED`)
+  - `cursor` (Long, 선택, `required=false`): 직전 마지막 reviewId
+  - `limit` (int, 선택, 기본값 `20`)
+- **요청 본문**: 없음
+- **응답**: `List<ReviewSummaryResponse>` (리스트 래퍼 없이 배열 직접 반환):
+  - 각 항목 `ReviewSummaryResponse`:
+    - `reviewId` (Long)
+    - `book` (object `BookInfo`): `bookId` (Long), `title` (String), `author` (String), `coverImageUrl` (String)
+    - `rating` (byte)
+    - `content` (String)
+    - `quote` (String)
+    - `isSpoiler` (boolean, JSON 키 `isSpoiler`)
+    - `reviewVisibility` (ReviewVisibility)
+    - `reviewStatus` (ReviewStatus)
+    - `likeCount` (int)
+    - `commentCount` (int)
+    - `isLiked` (boolean, JSON 키 `isLiked`)
+    - `tags` (array of String)
+    - `createdAt` (LocalDateTime)
+- **성공 상태**: 200
+
+### GET /api/v1/members/{userId}/reviews
+
+- **목적**: 타 유저 감상 목록 조회 (커서 페이지네이션)
+- **인증**: 공개 (GET_PERMIT_ALL에 `/api/v1/members/{userId}/reviews` 포함; 로그인 시 `requestingUserId` 로 `isLiked` 등 반영 — 선택적 인증)
+- **파라미터**:
+  - `userId` (Long, path, 필수)
+  - query:
+    - `cursor` (Long, 선택, `required=false`): 직전 마지막 reviewId
+    - `limit` (int, 선택, 기본값 `20`)
+- **요청 본문**: 없음
+- **응답**: `List<ReviewSummaryResponse>` (위 `/reviews/me` 와 동일 항목 구조, 배열 직접 반환)
+- **성공 상태**: 200
+
+### POST /api/v1/reviews/{reviewId}/likes
+
+- **목적**: 감상 좋아요
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터**:
+  - `reviewId` (Long, path, 필수)
+- **요청 본문**: 없음
+- **응답** (`ReviewLikeResponse`):
+  - `reviewId` (Long)
+  - `likeCount` (int)
+- **성공 상태**: **201 Created** (`@ResponseStatus(CREATED)`, message "좋아요를 눌렀습니다.")
+
+### DELETE /api/v1/reviews/{reviewId}/likes
+
+- **목적**: 감상 좋아요 취소
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터**:
+  - `reviewId` (Long, path, 필수)
+- **요청 본문**: 없음
+- **응답** (`ReviewLikeResponse`):
+  - `reviewId` (Long)
+  - `likeCount` (int)
+- **성공 상태**: 200 (message "좋아요가 취소되었습니다.")
+
+---
+
+## Library 도메인 (`/api/v1`, base path 분산)
+
+### POST /api/v1/library
+
+- **목적**: 내 서재에 도서 추가
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터**: 없음
+- **요청 본문** (`LibraryBookAddRequest`, `@Valid`):
+  - `bookId` (Long, 필수 — `@NotNull` "도서 ID는 필수입니다.")
+  - `status` (ReadingStatus enum, 필수 — `@NotNull` "독서 상태는 필수입니다." — `WANT_TO_READ`/`READING`/`FINISHED`/`STOPPED`)
+- **응답** (`LibraryBookAddResponse`):
+  - `libraryBookId` (Long)
+  - `bookId` (Long)
+  - `status` (ReadingStatus)
+  - `startedAt` (LocalDate, nullable)
+  - `finishedAt` (LocalDate, nullable)
+- **성공 상태**: **201 Created** (`@ResponseStatus(CREATED)`, message "도서가 서재에 추가되었습니다.")
+
+### GET /api/v1/library/me
+
+- **목적**: 내 서재 목록 조회 (상태 필터 + 커서 페이지네이션)
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터** (query):
+  - `status` (ReadingStatus enum, 선택, `required=false`)
+  - `cursor` (Long, 선택, `required=false`): 직전 마지막 libraryBookId
+  - `limit` (int, 선택, 기본값 `20`)
+- **요청 본문**: 없음
+- **응답** (`LibraryListResponse`):
+  - `content` (array of `LibraryBookSummaryResponse`):
+    - `libraryBookId` (Long)
+    - `book` (object `BookSummary`): `bookId` (Long), `isbn13` (String), `title` (String), `author` (String), `coverImageUrl` (String)
+    - `status` (ReadingStatus)
+    - `startedAt` (LocalDate, nullable)
+    - `finishedAt` (LocalDate, nullable)
+    - `hasReview` (boolean)
+  - `nextCursor` (Long, nullable — 마지막 항목 libraryBookId)
+  - `hasNext` (boolean)
+  - `size` (int)
+- **성공 상태**: 200
+
+### GET /api/v1/library/{libraryBookId}
+
+- **목적**: 서재 도서 상세 조회 (해당 도서의 내 리뷰 요약 포함)
+- **인증**: 인증 필요 (`anyRequest().authenticated()`; 컨트롤러가 `userDetails.getMember()` 직접 호출 — null 비허용)
+- **파라미터**:
+  - `libraryBookId` (Long, path, 필수)
+- **요청 본문**: 없음
+- **응답** (`LibraryBookDetailResponse`):
+  - `libraryBookId` (Long)
+  - `book` (object `BookDetail`): `bookId` (Long), `isbn13` (String), `title` (String), `author` (String), `publisher` (String), `coverImageUrl` (String), `totalPages` (Integer)
+  - `status` (ReadingStatus)
+  - `startedAt` (LocalDate, nullable)
+  - `finishedAt` (LocalDate, nullable)
+  - `review` (object `ReviewSummary`, nullable — 리뷰 없으면 null):
+    - `reviewId` (Long)
+    - `rating` (byte)
+    - `content` (String)
+    - `createdAt` (LocalDateTime)
+- **성공 상태**: 200
+
+### PATCH /api/v1/library/{libraryBookId}/status
+
+- **목적**: 서재 도서의 독서 상태 변경
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터**:
+  - `libraryBookId` (Long, path, 필수)
+- **요청 본문** (`LibraryStatusUpdateRequest`, `@Valid`):
+  - `status` (ReadingStatus enum, 필수 — `@NotNull` "독서 상태는 필수입니다.")
+- **응답** (`LibraryStatusUpdateResponse`):
+  - `libraryBookId` (Long)
+  - `status` (ReadingStatus)
+  - `startedAt` (LocalDate, nullable)
+  - `finishedAt` (LocalDate, nullable)
+- **성공 상태**: 200 (message "독서 상태가 변경되었습니다.")
+
+### DELETE /api/v1/library/{libraryBookId}
+
+- **목적**: 서재에서 도서 제거
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터**:
+  - `libraryBookId` (Long, path, 필수)
+- **요청 본문**: 없음
+- **응답**: `data` 없음 (`Void`) — message만 반환
+- **성공 상태**: 200 (message "서재에서 도서가 제거되었습니다.")
+
+### GET /api/v1/members/{userId}/library
+
+- **목적**: 타 유저 서재 목록 조회 (공개/비공개 처리 포함)
+- **인증**: 공개 (PERMIT_ALL에 `/api/v1/members/*/library` 포함; 로그인 시 `requestingUserId` 로 권한 판별 — 선택적 인증)
+- **파라미터**:
+  - `userId` (Long, path, 필수)
+  - query:
+    - `status` (ReadingStatus enum, 선택, `required=false`)
+    - `cursor` (Long, 선택, `required=false`): 직전 마지막 libraryBookId
+    - `limit` (int, 선택, 기본값 `20`)
+- **요청 본문**: 없음
+- **응답** (`UserLibraryResponse`):
+  - `libraryVisibility` (LibraryVisibility — `PUBLIC`/`PRIVATE`)
+  - `content` (array of `LibraryBookSummaryResponse` — PRIVATE 서재면 빈 배열):
+    - `libraryBookId` (Long)
+    - `book` (object `BookSummary`): `bookId` (Long), `isbn13` (String), `title` (String), `author` (String), `coverImageUrl` (String)
+    - `status` (ReadingStatus)
+    - `startedAt` (LocalDate, nullable)
+    - `finishedAt` (LocalDate, nullable)
+    - `hasReview` (boolean)
+  - `nextCursor` (Long, nullable — 마지막 항목 libraryBookId; PRIVATE면 null)
+  - `hasNext` (boolean — PRIVATE면 false)
+  - `size` (int — PRIVATE면 0)
+- **성공 상태**: 200
+
+### GET /api/v1/library/me/wisdom-tower
+
+- **목적**: 지혜의 탑 — 내가 완독한 도서 목록/총 개수 조회
+- **인증**: 인증 필요 (`anyRequest().authenticated()`)
+- **파라미터**: 없음
+- **요청 본문**: 없음
+- **응답** (`WisdomTowerResponse`):
+  - `totalCount` (int)
+  - `books` (array of `TowerItem`):
+    - `libraryBookId` (Long)
+    - `bookId` (Long)
+    - `title` (String)
+    - `finishedAt` (LocalDate, nullable)
+- **성공 상태**: 200
+
+---
+
+## 3. 피드 · 팔로우 · 차단 · 댓글 · 알림 (Feed / Follow / Block / Comment / Notification)
+
+### GET /api/v1/feed/following
+- **목적**: 내가 팔로우한 사용자들의 리뷰 피드를 커서 기반으로 조회.
+- **인증**: 인증 필요 (PERMIT_ALL 미포함 → `authenticated()`; `userDetails`를 null 체크 없이 사용).
+- **파라미터 (query)**:
+  - `cursor`: Long, optional, default 없음 — 직전 페이지 마지막 `feedId` (다음 페이지 시작 커서).
+  - `limit`: int, optional, default `20`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `FeedListResponse`
+  - `content`: `FeedItemResponse[]`
+    - `feedId`: Long
+    - `review`: object (`ReviewInfo`)
+      - `reviewId`: Long
+      - `user`: object — `userId`: Long, `nickname`: String, `profileImageUrl`: String
+      - `book`: object — `bookId`: Long, `title`: String, `author`: String, `coverImageUrl`: String
+      - `rating`: int
+      - `content`: String
+      - `quote`: String
+      - `isSpoiler`: Boolean
+      - `likeCount`: int
+      - `commentCount`: int
+      - `isLiked`: Boolean
+      - `tags`: String[]
+      - `createdAt`: LocalDateTime (ISO-8601)
+  - `nextCursor`: Long (nullable; `hasNext`가 false면 null이며 NON_NULL로 제외됨) — 다음 요청의 `cursor`로 사용.
+  - `hasNext`: boolean
+  - `size`: int (반환된 content 개수)
+
+### GET /api/v1/feed/recommend
+- **목적**: 추천 알고리즘 기반 리뷰 피드 조회 (좋아요수 + reviewId 복합 커서).
+- **인증**: 인증 필요.
+- **파라미터 (query)**:
+  - `cursorLike`: Integer, optional, default 없음 — 직전 페이지 마지막 아이템의 `likeCount` (복합 커서 1).
+  - `cursorId`: Long, optional, default 없음 — 직전 페이지 마지막 아이템의 `reviewId` (복합 커서 2).
+  - `limit`: int, optional, default `20`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `RecommendFeedResponse`
+  - `content`: `RecommendItemResponse[]`
+    - `reviewId`: Long
+    - `user`: object — `userId`: Long, `nickname`: String, `profileImageUrl`: String
+    - `book`: object — `bookId`: Long, `title`: String, `author`: String, `coverImageUrl`: String, `category`: String
+    - `rating`: byte
+    - `content`: String
+    - `quote`: String
+    - `isSpoiler`: boolean (`@JsonProperty("isSpoiler")`)
+    - `likeCount`: int
+    - `commentCount`: int
+    - `isLiked`: boolean (`@JsonProperty("isLiked")`)
+    - `tags`: String[]
+    - `createdAt`: LocalDateTime
+  - `nextCursorId`: Long (nullable; null이면 제외) — 다음 요청의 `cursorId`.
+  - `nextCursorLike`: Integer (nullable; null이면 제외) — 다음 요청의 `cursorLike`.
+  - `hasNext`: boolean
+  - `size`: int
+  - `recommendType`: String (`CONTENT_BASED` | `SOCIAL` | `MIXED` | `POPULAR`)
+
+---
+
+## Follow / Block (`/api/v1/users`)
+
+### POST /api/v1/users/{userId}/follow
+- **목적**: 특정 사용자를 팔로우.
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `userId`: Long, required — 팔로우 대상 사용자 ID.
+- **요청 바디**: 없음.
+- **성공 상태**: `201 Created` (`@ResponseStatus(CREATED)`), message `"팔로우했습니다."`.
+- **응답**: `data` = `FollowResponse`
+  - `followId`: Long
+  - `followingUserId`: Long — 팔로우된 대상 userId
+  - `followerCount`: int — 대상의 팔로워 수
+  - `followingCount`: int — 나의 팔로잉 수
+
+### DELETE /api/v1/users/{userId}/follow
+- **목적**: 특정 사용자 언팔로우.
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `userId`: Long, required.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, message `"언팔로우했습니다."`, `data` = `UnfollowResponse`
+  - `followerCount`: int — 대상의 팔로워 수
+  - `followingCount`: int — 나의 팔로잉 수
+
+### GET /api/v1/users/{userId}/followers
+- **목적**: 특정 사용자의 팔로워 목록 조회.
+- **인증**: 공개 (`GET_PERMIT_ALL`에 포함). 단, 로그인 시 `userDetails`로 관계 플래그가 채워지고, 비로그인 시 null 허용.
+- **파라미터**:
+  - (path) `userId`: Long, required.
+  - (query) `cursor`: Long, optional, default 없음 — 직전 페이지 마지막 `userId`.
+  - (query) `limit`: int, optional, default `20`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `FollowListResponse`
+  - `content`: `FollowMemberResponse[]`
+    - `userId`: Long
+    - `nickname`: String
+    - `profileImageUrl`: String
+    - `bio`: String
+    - `isFollowing`: Boolean — 내가 이 사람을 팔로우하는지
+    - `isFollowedBy`: Boolean — 이 사람이 나를 팔로우하는지
+  - `nextCursor`: Long (nullable; null이면 제외) — 다음 요청의 `cursor`.
+  - `hasNext`: boolean
+  - `size`: int
+
+### GET /api/v1/users/{userId}/following
+- **목적**: 특정 사용자가 팔로우하는 사용자 목록 조회.
+- **인증**: 공개 (`GET_PERMIT_ALL`에 포함). 로그인 시 관계 플래그 반영, 비로그인 허용.
+- **파라미터**:
+  - (path) `userId`: Long, required.
+  - (query) `cursor`: Long, optional, default 없음 — 직전 페이지 마지막 `userId`.
+  - (query) `limit`: int, optional, default `20`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `FollowListResponse` (구조는 위 followers와 동일: `content[FollowMemberResponse]`, `nextCursor`(nullable), `hasNext`, `size`).
+
+### POST /api/v1/users/{userId}/block
+- **목적**: 특정 사용자 차단.
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `userId`: Long, required.
+- **요청 바디**: 없음.
+- **성공 상태**: `201 Created` (`@ResponseStatus(CREATED)`), message `"사용자를 차단했습니다."`.
+- **응답**: `data` = 없음 (`ApiResponse<Void>`; `data` 필드는 null → 제외).
+
+### DELETE /api/v1/users/{userId}/block
+- **목적**: 특정 사용자 차단 해제.
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `userId`: Long, required.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, message `"차단이 해제되었습니다."`, `data` 없음 (`ApiResponse<Void>`).
+
+### GET /api/v1/users/me/blocks
+- **목적**: 내가 차단한 사용자 목록 조회.
+- **인증**: 인증 필요 (`GET_PERMIT_ALL` 미포함; `userDetails`를 null 체크 없이 사용).
+- **파라미터 (query)**:
+  - `cursor`: Long, optional, default 없음.
+  - `limit`: int, optional, default `20`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `BlockListResponse` (block 도메인 DTO — 본 작업 범위 외이나, 명세 일관성상 cursor/limit는 Long/int 동일).
+
+---
+
+## Comment (`/api/v1/reviews`)
+
+### POST /api/v1/reviews/{reviewId}/comments
+- **목적**: 리뷰에 댓글(또는 대댓글) 작성.
+- **인증**: 인증 필요 (POST는 `GET_PERMIT_ALL` 영향 없음).
+- **파라미터 (path)**: `reviewId`: Long, required.
+- **요청 바디** (`CommentCreateRequest`, JSON):
+  - `content`: String, **required** — `@NotNull("댓글 내용은 필수입니다.")`.
+  - `parentCommentId`: Long, optional (nullable) — null이면 원댓글, 값이 있으면 대댓글.
+- **성공 상태**: `201 Created` (`@ResponseStatus(CREATED)`), message `"댓글이 등록되었습니다."`.
+- **응답**: `data` = `CommentCreateResponse`
+  - `commentId`: Long
+  - `reviewId`: Long
+  - `user`: object — `userId`: Long, `nickname`: String, `profileImageUrl`: String
+  - `content`: String
+  - `parentCommentId`: Long (nullable; null이면 제외)
+  - `likeCount`: int
+  - `createdAt`: LocalDateTime
+
+### GET /api/v1/reviews/{reviewId}/comments
+- **목적**: 리뷰의 댓글 목록 조회 (대댓글 포함, 커서 기반).
+- **인증**: 공개 (`GET_PERMIT_ALL`에 포함). 로그인 시 `isMine`/`isLiked` 반영, 비로그인 허용.
+- **파라미터**:
+  - (path) `reviewId`: Long, required.
+  - (query) `cursor`: Long, optional, default 없음 — 직전 페이지 마지막 `commentId`.
+  - (query) `limit`: int, optional, default `20`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `CommentListResponse`
+  - `content`: `CommentResponse[]`
+    - `commentId`: Long
+    - `user`: object — `userId`: Long, `nickname`: String, `profileImageUrl`: String (소프트 삭제 시 `user` = null → 제외)
+    - `content`: String (소프트 삭제 시 `"삭제된 댓글입니다"`)
+    - `parentCommentId`: Long (nullable; null이면 제외)
+    - `likeCount`: int
+    - `isLiked`: Boolean
+    - `isDeleted`: Boolean
+    - `isMine`: Boolean
+    - `isEdited`: Boolean
+    - `createdAt`: LocalDateTime
+    - `replies`: `ReplyResponse[]`
+      - `commentId`: Long
+      - `user`: object — `userId`: Long, `nickname`: String, `profileImageUrl`: String (소프트 삭제 시 null)
+      - `content`: String (소프트 삭제 시 `"삭제된 댓글입니다"`)
+      - `parentCommentId`: Long
+      - `likeCount`: int
+      - `isLiked`: Boolean
+      - `isDeleted`: Boolean
+      - `isMine`: Boolean
+      - `isEdited`: Boolean
+      - `createdAt`: LocalDateTime
+  - `nextCursor`: Long (nullable; null이면 제외) — 다음 요청의 `cursor`.
+  - `hasNext`: boolean
+  - `size`: int
+
+### PUT /api/v1/reviews/{reviewId}/comments/{commentId}
+- **목적**: 댓글 수정.
+- **인증**: 인증 필요 (PUT는 GET 공개 규칙 미적용).
+- **파라미터 (path)**: `reviewId`: Long, required; `commentId`: Long, required.
+- **요청 바디** (`CommentUpdateRequest`, JSON):
+  - `content`: String, **required** — `@NotNull("댓글 내용은 필수입니다.")`.
+- **응답**: `200 OK`, message `"댓글이 수정되었습니다."`, `data` = `CommentUpdateResponse`
+  - `commentId`: Long
+  - `content`: String
+  - `updatedAt`: LocalDateTime
+
+### DELETE /api/v1/reviews/{reviewId}/comments/{commentId}
+- **목적**: 댓글 삭제 (소프트 삭제).
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `reviewId`: Long, required; `commentId`: Long, required.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, message `"댓글이 삭제되었습니다."`, `data` 없음 (`ApiResponse<Void>`).
+
+### POST /api/v1/reviews/{reviewId}/comments/{commentId}/likes
+- **목적**: 댓글 좋아요.
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `reviewId`: Long, required; `commentId`: Long, required.
+- **요청 바디**: 없음.
+- **성공 상태**: `201 Created` (`@ResponseStatus(CREATED)`), message `"좋아요를 눌렀습니다."`.
+- **응답**: `data` = `CommentLikeResponse`
+  - `commentId`: Long
+  - `likeCount`: int
+
+### DELETE /api/v1/reviews/{reviewId}/comments/{commentId}/likes
+- **목적**: 댓글 좋아요 취소.
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `reviewId`: Long, required; `commentId`: Long, required.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, message `"좋아요가 취소되었습니다."`, `data` = `CommentLikeResponse`
+  - `commentId`: Long
+  - `likeCount`: int
+
+---
+
+## Notification (`/api/v1/notifications`)
+
+> 컨트롤러에 `@Validated` 적용 → path/query 파라미터 제약 검증 활성화.
+
+### GET /api/v1/notifications
+- **목적**: 내 알림 목록 조회 (불투명 String 커서 기반 페이지네이션).
+- **인증**: 인증 필요.
+- **파라미터 (query)**:
+  - `cursor`: **String (opaque)**, optional, default 없음 — 서버가 발급한 불투명 커서 문자열(Long 아님). 다음 페이지 요청 시 직전 응답의 `nextCursor`를 그대로 전달.
+  - `limit`: int, optional, default `20`, 제약 `@Min(1)`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `NotificationListResponse`
+  - `content`: `NotificationItemResponse[]`
+    - `notificationId`: Long
+    - `type`: `NotificationType` (enum, 문자열로 직렬화)
+    - `message`: String
+    - `isRead`: boolean (`@JsonProperty("isRead")`)
+    - `actor`: object (nullable; actor 없으면 null → 제외)
+      - `userId`: Long
+      - `nickname`: String
+      - `profileImageUrl`: String
+    - `reviewId`: Long (nullable; null이면 제외)
+    - `commentId`: Long (nullable; null이면 제외)
+    - `followId`: Long (nullable; null이면 제외)
+    - `createdAt`: LocalDateTime
+  - `nextCursor`: String (opaque, nullable; `hasNext` false면 null → 제외) — 다음 요청의 `cursor`.
+  - `hasNext`: boolean
+  - `size`: int
+
+### PATCH /api/v1/notifications/{notificationId}/read
+- **목적**: 단일 알림 읽음 처리.
+- **인증**: 인증 필요.
+- **파라미터 (path)**: `notificationId`: Long, required — 제약 `@Positive("유효하지 않은 알림 ID입니다.")`.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, message `"알림을 읽음 처리했습니다."`, `data` 없음 (`ApiResponse<Void>`).
+
+### PATCH /api/v1/notifications/read-all
+- **목적**: 내 모든 알림 일괄 읽음 처리.
+- **인증**: 인증 필요.
+- **파라미터**: 없음.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, message `"모든 알림을 읽음 처리했습니다."`, `data` 없음 (`ApiResponse<Void>`).
+
+### GET /api/v1/notifications/unread-count
+- **목적**: 미읽음 알림 개수 조회.
+- **인증**: 인증 필요.
+- **파라미터**: 없음.
+- **요청 바디**: 없음.
+- **응답**: `200 OK`, `data` = `UnreadCountResponse`
+  - `unreadCount`: long
+
+---
+
+## 4. 장르 · 검색 · OCR · 신고 (Genre / Search / OCR / Report)
+
+### GET /api/v1/genres
+- **목적**: 전체 장르 목록 조회
+- **인증**: 공개 (SecurityConfig `GET_PERMIT_ALL`에 `/api/v1/genres` 포함)
+- **파라미터**: 없음
+- **요청**: 없음
+- **응답**: `200 OK`, `ApiResponse<GenreListResponse>`
+  - `data.genres`: array of object
+    - `genreId` (Long)
+    - `name` (String) — 장르명(`genreName`)
+
+---
+
+### GET /api/v1/search
+- **목적**: 책/사용자 통합 검색 (커서 기반 페이지네이션)
+- **인증**: 공개 (`GET_PERMIT_ALL`에 `/api/v1/search` 포함). 단, 로그인 시 토큰의 사용자 기준으로 `users[].isFollowing`이 채워짐(비로그인 시 memberUserId=null)
+- **파라미터 (query)**:
+  - `query` (String, 필수) — 검색어
+  - `type` (String, 선택, default `"all"`) — 검색 대상 구분 (예: `all`/`books`/`users`)
+  - `cursor` (Long, 선택) — 다음 페이지 커서
+  - `limit` (int, 선택, default `20`) — 페이지 크기
+- **요청 바디**: 없음
+- **응답**: `200 OK`, `ApiResponse<SearchResponse>`
+  - `data.books`: `SearchPageResponse<BookSearchResult>`
+    - `content`: array of object
+      - `bookId` (Long)
+      - `isbn13` (String)
+      - `title` (String)
+      - `author` (String)
+      - `coverImageUrl` (String)
+      - `averageRating` (Double, 소수점 1자리 반올림, null 가능)
+      - `reviewCount` (Long)
+    - `nextCursor` (Long, null 가능)
+    - `hasNext` (boolean)
+    - `size` (int)
+  - `data.users`: `SearchPageResponse<UserSearchResult>`
+    - `content`: array of object
+      - `userId` (Long)
+      - `nickname` (String)
+      - `profileImageUrl` (String)
+      - `bio` (String)
+      - `followerCount` (int)
+      - `isFollowing` (Boolean)
+    - `nextCursor` (Long, null 가능)
+    - `hasNext` (boolean)
+    - `size` (int)
+  - (검색 type에 따라 books 또는 users가 빈 페이지(`empty()`: content=[], nextCursor=null, hasNext=false, size=0)일 수 있음)
+
+---
+
+### POST /api/v1/ocr/extract-text
+- **목적**: Base64 이미지에서 OCR로 텍스트 추출 (전체 텍스트 + 블록별 좌표)
+- **인증**: 인증 필요 (PERMIT_ALL/GET_PERMIT_ALL에 없음 → `anyRequest().authenticated()`)
+- **파라미터**: 없음
+- **요청 바디**: `OcrExtractRequest` (JSON, `@Valid`)
+  - `imageData` (String, 필수) — Base64 인코딩 이미지 데이터. `@NotBlank`, `@Size(max=7_000_000)` (약 5MB 초과 불가; 문자열 길이 기준 7,000,000자)
+  - `imageFormat` (String, 필수) — 이미지 형식(jpg, png 등). `@NotBlank`
+- **응답**: `200 OK`, `ApiResponse<OcrExtractResponse>`
+  - `data.extractedText` (String) — 추출된 전체 텍스트
+  - `data.fields`: array of `OcrTextField`
+    - `text` (String) — 텍스트 블록 내용
+    - `lineBreak` (boolean) — true면 블록 뒤 줄바꿈
+    - `vertices`: array of `Vertex` — 이미지 내 위치 좌표
+      - `x` (double)
+      - `y` (double)
+
+---
+
+### POST /api/v1/reports
+- **목적**: 리뷰/댓글 신고 접수
+- **인증**: 인증 필요 (`anyRequest().authenticated()`; userDetails에서 memberUserId 추출)
+- **파라미터**: 없음
+- **요청 바디**: `ReportRequest` (JSON, `@Valid`)
+  - `targetType` (enum `ReportTargetType`, 필수, `@NotNull`) — 허용값: `REVIEW`, `COMMENT`
+  - `targetId` (Long, 필수, `@NotNull`) — 신고 대상 ID
+  - `reason` (enum `ReportReason`, 필수, `@NotNull`) — 허용값: `SPOILER`, `SPAM`, `INAPPROPRIATE`, `COPYRIGHT`, `OTHER`
+  - `description` (String, 선택) — `@Size(max=200)`
+- **응답**: `201 Created` (`@ResponseStatus(HttpStatus.CREATED)`, message `"신고가 접수되었습니다."`), `ApiResponse<ReportResponse>`
+  - `data.reportId` (Long)
+  - `data.targetType` (enum `ReportTargetType`)
+  - `data.targetId` (Long)
+  - `data.reason` (enum `ReportReason`)
+  - `data.createdAt` (LocalDateTime, ISO-8601)
+
+---

--- a/docs/ssm-migration.md
+++ b/docs/ssm-migration.md
@@ -1,0 +1,131 @@
+# AWS SSM Parameter Store 마이그레이션 가이드
+
+## 개요
+
+현재 운영 시크릿은 `.env`(평문) + `me.paulschwarz:spring-dotenv`로 주입된다.
+이 문서는 운영 환경에서 AWS SSM Parameter Store로 시크릿을 이관하기 위한 절차와 컨벤션을 정의한다.
+
+`application-prod.yml`에 `optional:aws-parameterstore:/config/shelfeed/` import가 추가되어 있으므로,
+SSM에 파라미터가 존재하면 자동으로 로드되어 기존 환경변수 값을 오버라이드한다.
+`optional:` 접두사 덕분에 SSM 미구성 또는 IAM 권한 부재 시에도 부팅이 중단되지 않고
+기존 `.env` 기반 환경변수 fallback이 그대로 동작한다.
+
+---
+
+## SSM 파라미터 경로 컨벤션
+
+모든 파라미터는 `/config/shelfeed/<property-key>` 형식으로 저장한다.
+
+- `<property-key>`는 Spring 프로퍼티 키와 1:1 매핑된다.
+- 계층 구분자는 `.`(점)을 사용한다.
+- 예: `/config/shelfeed/spring.datasource.password`
+
+Spring Cloud AWS는 `/config/shelfeed/` 경로 아래의 파라미터를 `GetParametersByPath`로 일괄 조회하여
+Spring Environment에 주입한다. 경로의 마지막 세그먼트가 프로퍼티 키로 변환된다.
+
+---
+
+## 시크릿 매핑표
+
+| 환경변수 (현재 `.env`) | SSM 파라미터 경로 | application.yml 프로퍼티 키 |
+|---|---|---|
+| `JWT_SECRET` | `/config/shelfeed/jwt.secret` | `jwt.secret` |
+| `GOOGLE_CLIENT_ID` | `/config/shelfeed/oauth2.google.client-id` | `oauth2.google.client-id` |
+| `GOOGLE_CLIENT_SECRET` | `/config/shelfeed/oauth2.google.client-secret` | `oauth2.google.client-secret` |
+| `GOOGLE_REDIRECT_URI` | `/config/shelfeed/oauth2.google.redirect-uri` | `oauth2.google.redirect-uri` |
+| `ALADIN_API_KEY` | `/config/shelfeed/aladin.api.ttbkey` | `aladin.api.ttbkey` |
+| `CLOVA_OCR_SECRET_KEY` | `/config/shelfeed/clova.ocr.secret-key` | `clova.ocr.secret-key` |
+| `CLOVA_OCR_API_URL` | `/config/shelfeed/clova.ocr.api-url` | `clova.ocr.api-url` |
+| `MAIL_USERNAME` | `/config/shelfeed/spring.mail.username` | `spring.mail.username` |
+| `MAIL_PASSWORD` | `/config/shelfeed/spring.mail.password` | `spring.mail.password` |
+| `ADMIN_EMAIL` | `/config/shelfeed/admin.email` | `admin.email` |
+| `ADMIN_PASSWORD` | `/config/shelfeed/admin.password` | `admin.password` |
+| `DB_URL` | `/config/shelfeed/spring.datasource.url` | `spring.datasource.url` |
+| `DB_USERNAME` | `/config/shelfeed/spring.datasource.username` | `spring.datasource.username` |
+| `DB_PASSWORD` | `/config/shelfeed/spring.datasource.password` | `spring.datasource.password` |
+
+> 참고: `GOOGLE_CLIENT_ID`는 시크릿은 아니지만 일관성을 위해 SSM에 함께 관리할 수 있다.
+> `MAIL_HOST`, `MAIL_PORT`, `MAIL_BCC` 등 비시크릿 값은 SSM 이관 대상에서 제외해도 무방하다.
+
+---
+
+## EC2 인스턴스 IAM 권한 요구사항
+
+운영 EC2 인스턴스에 연결된 IAM 역할에 아래 정책이 필요하다.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParametersByPath",
+        "ssm:GetParameter",
+        "ssm:GetParameters"
+      ],
+      "Resource": "arn:aws:ssm:<REGION>:<ACCOUNT_ID>:parameter/config/shelfeed/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "arn:aws:kms:<REGION>:<ACCOUNT_ID>:key/<KMS_KEY_ID>"
+    }
+  ]
+}
+```
+
+- `<REGION>`: EC2가 위치한 리전 (예: `ap-northeast-2`)
+- `<ACCOUNT_ID>`: AWS 계정 ID
+- `<KMS_KEY_ID>`: SecureString 암호화에 사용한 KMS 키 ID (기본 `aws/ssm` 키 사용 시 KMS 정책 불필요)
+
+---
+
+## 남은 수동 단계 체크리스트
+
+### (a) SSM에 SecureString 파라미터 생성
+
+매핑표의 각 항목에 대해 AWS 콘솔 또는 CLI로 파라미터를 생성한다.
+
+```bash
+# 예시 (AWS CLI)
+aws ssm put-parameter \
+  --name "/config/shelfeed/spring.datasource.password" \
+  --value "실제_DB_비밀번호" \
+  --type SecureString \
+  --region ap-northeast-2
+```
+
+모든 시크릿 항목은 반드시 `SecureString` 타입으로 저장한다.
+
+### (b) EC2 IAM 역할에 SSM 읽기 권한 부여
+
+- AWS 콘솔 → IAM → 역할 → EC2 인스턴스 프로파일 역할 선택
+- 위 정책을 인라인 정책 또는 관리형 정책으로 연결
+- 변경 사항은 인스턴스 재시작 없이 즉시 적용됨
+
+### (c) 검증 후 prod yml의 `${ENV}` placeholder 제거 (cutover)
+
+1. 운영 서버에서 애플리케이션 재시작
+2. 로그에서 `Fetched config from aws-parameterstore` 확인
+3. 엔드포인트 정상 동작 확인 (DB 연결, JWT 인증, 이메일 발송 등)
+4. 검증 완료 후 `application-prod.yml`의 `${DB_PASSWORD}`, `${DB_URL}`, `${DB_USERNAME}` 등 placeholder를 제거
+
+### (d) `.env`에서 해당 키 삭제 및 **실제 키 로테이션**
+
+- cutover 검증 완료 후 `.env`에서 SSM으로 이관된 항목 삭제
+- **DB 비밀번호, JWT 시크릿, OAuth 클라이언트 시크릿, OCR 키 등 모든 시크릿을 실제로 재발급/로테이션**
+- 기존 값이 형상관리(git history, 로그 등)에 노출된 경우 반드시 로테이션 필요
+
+---
+
+## 현재 상태 (groundwork 완료)
+
+- [x] `build.gradle.kts`: `spring-cloud-aws-starter-parameter-store:3.2.1` 의존성 추가
+- [x] `application-prod.yml`: `spring.config.import: optional:aws-parameterstore:/config/shelfeed/` 추가
+- [ ] SSM 파라미터 생성 (수동)
+- [ ] IAM 권한 부여 (수동)
+- [ ] 운영 검증 및 cutover (수동)
+- [ ] 시크릿 로테이션 (수동)

--- a/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/shelfeed/backend/domain/auth/service/AuthService.java
@@ -80,11 +80,8 @@ public class AuthService {
         // 이메일 인증 코드 생성 후 Redis에 저장 (5분 TTL)
         String code = generateSixDigitCode();
         redisService.saveEmailCode(request.getEmail(), code, 300);
-        try {
-            emailService.sendVerificationEmail(request.getEmail(), code);
-        } catch (EmailSendException e) {
-            log.warn("[EMAIL] 인증 이메일 발송 실패 — 재발송 API로 재시도 가능", e);
-        }
+        // 비동기 발송 — SMTP 지연이 회원가입 응답을 막지 않도록(발송 실패는 재발송 API로 복구). 발송 실패 로깅은 비동기 메서드 내부에서 처리.
+        emailService.sendVerificationEmailAsync(request.getEmail(), code);
 
         String accessToken = jwtProvider.generateAccessToken(member);//인증 토큰
         String refreshToken = jwtProvider.generateRefreshToken(member);// 재발급 토큰
@@ -307,7 +304,8 @@ public class AuthService {
         }
         Long memberUserId;
         try {
-            if (!jwtProvider.validateToken(refreshToken)) {
+            // 서명/만료 검증 + refresh 타입 확인(access 토큰을 refresh로 사용하는 것을 차단)
+            if (!jwtProvider.validateToken(refreshToken) || !jwtProvider.isRefreshToken(refreshToken)) {
                 throw new BusinessException(ErrorCode.INVALID_TOKEN);
             }
             memberUserId = jwtProvider.getMemberUserId(refreshToken);
@@ -346,11 +344,8 @@ public class AuthService {
         if (memberOpt.isPresent()) {
             String token = UUID.randomUUID().toString();
             redisService.savePasswordResetToken(token, request.getEmail(), 1800);
-            try {
-                emailService.sendPasswordResetEmail(request.getEmail(), token);
-            } catch (EmailSendException e) {
-                log.warn("[EMAIL] 비밀번호 재설정 이메일 발송 실패", e);
-            }
+            // 비동기 fire-and-forget — 발송 실패 로깅은 비동기 메서드 내부에서 처리(존재 여부 노출 방지 위해 호출자는 항상 무음)
+            emailService.sendPasswordResetEmail(request.getEmail(), token);
         }
     }
 

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookPersistenceService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookPersistenceService.java
@@ -1,0 +1,136 @@
+package com.shelfeed.backend.domain.book.service;
+
+import com.shelfeed.backend.domain.book.client.dto.AladinItem;
+import com.shelfeed.backend.domain.book.document.BookDocument;
+import com.shelfeed.backend.domain.book.entity.Book;
+import com.shelfeed.backend.domain.book.repository.BookRepository;
+import com.shelfeed.backend.domain.book.repository.BookSearchRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 알라딘 도서 영속화 전담 빈.
+ * 외부 HTTP 호출은 BookService가 트랜잭션 밖에서 수행하고,
+ * DB 쓰기/ES 색인만 이 빈의 트랜잭션 가진 메서드로 위임받는다.
+ * (별도 빈 → 프록시 경유로 새 트랜잭션이 정상적으로 시작됨)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookPersistenceService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final BookRepository bookRepository;
+    private final BookSearchRepository bookSearchRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    // ES 색인 성공 여부와 isbn→Book 맵을 함께 반환 — 호출자가 색인 실패 시 Redis 마커 등을 스킵할 수 있도록 분리
+    public record UpsertResult(Map<String, Book> books, boolean indexed) {}
+
+    /**
+     * DB에 없는 도서만 저장하고 전체 isbn→Book 맵과 ES 색인 결과를 반환한다.
+     * searchBooks()와 syncFromAladin() 모두 이 메서드를 통해 upsert 한다.
+     */
+    @Transactional
+    public UpsertResult upsertAndGetBooks(List<AladinItem> items) {
+        List<String> isbns = items.stream().map(AladinItem::getIsbn13).toList();
+        Map<String, Book> existing = bookRepository.findByIsbn13In(isbns).stream()
+                .collect(Collectors.toMap(Book::getIsbn13, b -> b));
+
+        List<Book> newBooks = items.stream()
+                .filter(item -> !existing.containsKey(item.getIsbn13()))
+                .map(this::createBookFromItem)
+                .toList();
+
+        Map<String, Book> all = new HashMap<>(existing);
+        List<Book> toIndex = new ArrayList<>();
+        if (!newBooks.isEmpty()) {
+            try {
+                // saveAllAndFlush로 즉시 flush — try 블록 내에서 unique 위반 발생하도록
+                bookRepository.saveAllAndFlush(newBooks);
+                newBooks.forEach(b -> all.put(b.getIsbn13(), b));
+                toIndex.addAll(newBooks);
+            } catch (DataIntegrityViolationException e) {
+                // 동시 요청으로 인한 unique 위반 — Session에 null ID 엔티티가 남아있으므로
+                // clear() 후 재조회해야 AssertionFailure를 방지할 수 있다.
+                log.warn("도서 saveAll unique 위반 (동시 요청 추정), 재조회 진행: isbns={}", isbns);
+                entityManager.clear();
+                List<Book> refetched = bookRepository.findByIsbn13In(isbns);
+                refetched.forEach(b -> all.put(b.getIsbn13(), b));
+                toIndex.addAll(refetched); // 멱등 — 이미 색인된 책도 동일 ID로 덮어쓰기
+            }
+        }
+        // ES 색인은 트랜잭션 외부 효과 — DB 저장 성공 후 best-effort 색인 (성공 여부 반환)
+        boolean indexed = indexToElasticsearch(toIndex);
+        return new UpsertResult(all, indexed);
+    }
+
+    // 알라딘 아이템 → DB Book (없으면 저장) - 단건 조회용 (getBookByIsbn 등)
+    // 신규 저장 시 ES에도 색인 (실패해도 무시 — BookIndexInitializer로 보강)
+    @Transactional
+    public Book findOrCreateBook(AladinItem item) {
+        return bookRepository.findByIsbn13(item.getIsbn13())
+                .orElseGet(() -> {
+                    Book saved = bookRepository.save(createBookFromItem(item));
+                    indexToElasticsearch(List.of(saved));
+                    return saved;
+                });
+    }
+
+    // 알라딘 아이템 → Book 엔티티 생성 (저장 없이 객체만 반환, saveAll용)
+    private Book createBookFromItem(AladinItem item) {
+        LocalDate pubDate = null;
+        try {
+            pubDate = LocalDate.parse(item.getPubDate());
+        } catch (Exception ignored) {}
+        Integer totalPages = item.getSubInfo() != null ? item.getSubInfo().getItemPage() : null;
+        String author = item.getAuthor();
+        if (author != null && author.length() > 50) author = author.substring(0, 50);
+        return Book.create(
+                item.getIsbn13(), item.getTitle(), author, item.getPublisher(),
+                item.getCover(), item.getDescription(), totalPages, pubDate,
+                item.getItemId() != null ? String.valueOf(item.getItemId()) : null,
+                item.getCategoryName(),
+                extractGenre(item.getCategoryName())
+        );
+    }
+
+    // "국내도서>소설/시/희곡>한국소설" → "소설/시/희곡", "소설" → "소설" (단일 계층도 보존)
+    private String extractGenre(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) return null;
+        String[] parts = categoryName.split(">");
+        return parts.length >= 2 ? parts[1].trim() : parts[0].trim();
+    }
+
+    // ES 색인 — 실패해도 트랜잭션 영향 없음 (BookIndexInitializer로 재동기화 가능)
+    // refresh() 호출로 색인 즉시 검색 가능 상태로 전환 — 같은 요청에서 알라딘 캐싱 → 검색 사용 가능
+    private boolean indexToElasticsearch(List<Book> books) {
+        if (books.isEmpty()) return true;
+        try {
+            List<BookDocument> docs = books.stream().map(BookDocument::from).toList();
+            bookSearchRepository.saveAll(docs);
+            elasticsearchOperations.indexOps(BookDocument.class).refresh();
+            return true;
+        } catch (Exception e) {
+            log.warn("ES 색인 실패 (count={}), 검색에 즉시 반영 안 됨: error={}",
+                    books.size(), e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookService.java
@@ -3,13 +3,11 @@ package com.shelfeed.backend.domain.book.service;
 import com.shelfeed.backend.domain.book.client.AladinClient;
 import com.shelfeed.backend.domain.book.client.dto.AladinItem;
 import com.shelfeed.backend.domain.book.client.dto.AladinSearchResponse;
-import com.shelfeed.backend.domain.book.document.BookDocument;
 import com.shelfeed.backend.domain.book.dto.request.BookReviewSearchRequest;
 import com.shelfeed.backend.domain.book.dto.request.BookSearchRequest;
 import com.shelfeed.backend.domain.book.dto.response.*;
 import com.shelfeed.backend.domain.book.entity.Book;
 import com.shelfeed.backend.domain.book.repository.BookRepository;
-import com.shelfeed.backend.domain.book.repository.BookSearchRepository;
 import com.shelfeed.backend.domain.library.entity.LibraryBook;
 import com.shelfeed.backend.domain.library.enums.ReadingStatus;
 import com.shelfeed.backend.domain.library.repository.LibraryRepository;
@@ -21,19 +19,13 @@ import com.shelfeed.backend.domain.review.repository.ReviewRepository;
 import com.shelfeed.backend.domain.block.repository.BlockRepository;
 import com.shelfeed.backend.global.common.exception.BusinessException;
 import com.shelfeed.backend.global.common.exception.ErrorCode;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,22 +41,18 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class BookService {
 
-    @PersistenceContext
-    private EntityManager entityManager;
-
     private final BookRepository bookRepository;
-    private final BookSearchRepository bookSearchRepository;
-    private final ElasticsearchOperations elasticsearchOperations;
     private final MemberRepository memberRepository;
     private final LibraryRepository libraryRepository;
     private final ReviewRepository reviewRepository;
     private final ReviewLikeRepository reviewLikeRepository;
     private final AladinClient aladinApiClient;
     private final BlockRepository blockRepository;
+    private final BookPersistenceService bookPersistenceService;
 
 
-    // 1. 도서 검색
-    @Transactional
+    // 1. 도서 검색 — 외부 HTTP는 트랜잭션 밖(NOT_SUPPORTED), DB 쓰기는 BookPersistenceService 위임
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public BookSearchListResponse searchBooks(BookSearchRequest request, Long memberUserId) {
         AladinSearchResponse response = aladinApiClient.search(request.getQuery(), request.getPage(), request.getLimit() + 1); //무한스크롤을 위해 +1 개 더 조회
         if (response == null || response.getItems() == null) {
@@ -77,7 +65,7 @@ public class BookService {
             return BookSearchListResponse.of(List.of(), request.getLimit());
         }
 
-        Map<String, Book> allBooksMap = upsertAndGetBooks(items).books();
+        Map<String, Book> allBooksMap = bookPersistenceService.upsertAndGetBooks(items).books();
         List<Book> allBooks = items.stream()
                 .map(item -> allBooksMap.get(item.getIsbn13()))
                 .filter(Objects::nonNull)
@@ -129,8 +117,8 @@ public class BookService {
         return BookDetailResponse.of(book,averageRating,reviewCount,myLibraryStatus,myLibraryBookId,myReviewId);
     }
 
-    // 3. ISBN 조회
-    @Transactional
+    // 3. ISBN 조회 — 외부 HTTP는 트랜잭션 밖(NOT_SUPPORTED), DB 쓰기는 BookPersistenceService 위임
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public BookDetailResponse getBookByIsbn(String isbn13, Long memberUserId) {
         Optional<Book> existing = bookRepository.findByIsbn13(isbn13);
         Book book = existing.orElseGet(() -> {
@@ -138,7 +126,7 @@ public class BookService {
             if (response == null || response.getItems() == null || response.getItems().isEmpty()) {
                 throw new BusinessException(ErrorCode.BOOK_NOT_FOUND);
             }
-            return findOrCreateBook(response.getItems().get(0));
+            return bookPersistenceService.findOrCreateBook(response.getItems().get(0));
         });
 
         boolean inMyLibrary = false;
@@ -187,57 +175,6 @@ public class BookService {
         return BookReviewListResponse.of(content, request.getLimit(), isRatingSort, isPopularSort);
     }
 
-    // 알라딘 아이템 → Book 엔티티 생성 (저장 없이 객체만 반환, saveAll용)
-    private Book createBookFromItem(AladinItem item) {
-        LocalDate pubDate = null;
-        try {
-            pubDate = LocalDate.parse(item.getPubDate());
-        } catch (Exception ignored) {}
-        Integer totalPages = item.getSubInfo() != null ? item.getSubInfo().getItemPage() : null;
-        String author = item.getAuthor();
-        if (author != null && author.length() > 50) author = author.substring(0, 50);
-        return Book.create(
-                item.getIsbn13(), item.getTitle(), author, item.getPublisher(),
-                item.getCover(), item.getDescription(), totalPages, pubDate,
-                item.getItemId() != null ? String.valueOf(item.getItemId()) : null,
-                item.getCategoryName(),
-                extractGenre(item.getCategoryName())
-        );
-    }
-
-    // "국내도서>소설/시/희곡>한국소설" → "소설/시/희곡", "소설" → "소설" (단일 계층도 보존)
-    private String extractGenre(String categoryName) {
-        if (categoryName == null || categoryName.isBlank()) return null;
-        String[] parts = categoryName.split(">");
-        return parts.length >= 2 ? parts[1].trim() : parts[0].trim();
-    }
-
-    // 알라딘 아이템 → DB Book (없으면 저장) - 단건 조회용 (getBookByIsbn 등)
-    // 신규 저장 시 ES에도 색인 (실패해도 무시 — BookIndexInitializer로 보강)
-    private Book findOrCreateBook(AladinItem item) {
-        return bookRepository.findByIsbn13(item.getIsbn13())
-                .orElseGet(() -> {
-                    Book saved = bookRepository.save(createBookFromItem(item));
-                    indexToElasticsearch(List.of(saved));
-                    return saved;
-                });
-    }
-
-    // ES 색인 — 실패해도 트랜잭션 영향 없음 (BookIndexInitializer로 재동기화 가능)
-    // refresh() 호출로 색인 즉시 검색 가능 상태로 전환 — 같은 요청에서 알라딘 캐싱 → 검색 사용 가능
-    private boolean indexToElasticsearch(List<Book> books) {
-        if (books.isEmpty()) return true;
-        try {
-            List<BookDocument> docs = books.stream().map(BookDocument::from).toList();
-            bookSearchRepository.saveAll(docs);
-            elasticsearchOperations.indexOps(BookDocument.class).refresh();
-            return true;
-        } catch (Exception e) {
-            log.warn("ES 색인 실패 (count={}), 검색에 즉시 반영 안 됨: error={}",
-                    books.size(), e.getMessage());
-            return false;
-        }
-    }
     //맵버 찾거나 없으면 null
     private Member getMemberOrNull(Long memberUserId) {
         return memberRepository.findByMemberUserId(memberUserId).orElse(null);
@@ -254,57 +191,18 @@ public class BookService {
                 .values().stream().toList();
     }
 
-    // ES 색인 성공 여부와 isbn→Book 맵을 함께 반환 — 호출자가 색인 실패 시 Redis 마커 등을 스킵할 수 있도록 분리
-    private record UpsertResult(Map<String, Book> books, boolean indexed) {}
-
-    /**
-     * DB에 없는 도서만 저장하고 전체 isbn→Book 맵과 ES 색인 결과를 반환한다.
-     * searchBooks()와 syncFromAladin() 모두 이 메서드를 통해 upsert 한다.
-     */
-    private UpsertResult upsertAndGetBooks(List<AladinItem> items) {
-        List<String> isbns = items.stream().map(AladinItem::getIsbn13).toList();
-        Map<String, Book> existing = bookRepository.findByIsbn13In(isbns).stream()
-                .collect(Collectors.toMap(Book::getIsbn13, b -> b));
-
-        List<Book> newBooks = items.stream()
-                .filter(item -> !existing.containsKey(item.getIsbn13()))
-                .map(this::createBookFromItem)
-                .toList();
-
-        Map<String, Book> all = new HashMap<>(existing);
-        List<Book> toIndex = new ArrayList<>();
-        if (!newBooks.isEmpty()) {
-            try {
-                // saveAllAndFlush로 즉시 flush — try 블록 내에서 unique 위반 발생하도록
-                bookRepository.saveAllAndFlush(newBooks);
-                newBooks.forEach(b -> all.put(b.getIsbn13(), b));
-                toIndex.addAll(newBooks);
-            } catch (DataIntegrityViolationException e) {
-                // 동시 요청으로 인한 unique 위반 — Session에 null ID 엔티티가 남아있으므로
-                // clear() 후 재조회해야 AssertionFailure를 방지할 수 있다.
-                log.warn("도서 saveAll unique 위반 (동시 요청 추정), 재조회 진행: isbns={}", isbns);
-                entityManager.clear();
-                List<Book> refetched = bookRepository.findByIsbn13In(isbns);
-                refetched.forEach(b -> all.put(b.getIsbn13(), b));
-                toIndex.addAll(refetched); // 멱등 — 이미 색인된 책도 동일 ID로 덮어쓰기
-            }
-        }
-        // ES 색인은 트랜잭션 외부 효과 — DB 저장 성공 후 best-effort 색인 (성공 여부 반환)
-        boolean indexed = indexToElasticsearch(toIndex);
-        return new UpsertResult(all, indexed);
-    }
-
     /**
      * SearchService가 통합 검색 전 호출하는 알라딘 캐싱 메서드.
      * DB에 없는 도서를 INSERT 후 ES 색인까지 완료한다.
+     * 외부 HTTP는 트랜잭션 밖(NOT_SUPPORTED)에서 수행하고, DB 쓰기는 BookPersistenceService에 위임한다.
      * @return ES 색인까지 모두 성공한 경우만 true — 색인 실패 시 false 반환하여 호출자가 Redis 마커를 찍지 않도록 함
      */
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public boolean syncFromAladin(String query, int maxResults) {
         AladinSearchResponse response = aladinApiClient.search(query, 1, maxResults);
         if (response == null || response.getItems() == null || response.getItems().isEmpty()) return false;
         List<AladinItem> items = deduplicateByIsbn(response.getItems());
         if (items.isEmpty()) return false;
-        return upsertAndGetBooks(items).indexed();
+        return bookPersistenceService.upsertAndGetBooks(items).indexed();
     }
 }

--- a/src/main/java/com/shelfeed/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/shelfeed/backend/global/config/AsyncConfig.java
@@ -1,0 +1,31 @@
+package com.shelfeed.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * @EnableAsync(BackendApplication)가 사용할 바운디드 Executor.
+ * 명시적 Executor가 없으면 Spring이 무제한 SimpleAsyncTaskExecutor로 폴백하므로,
+ * 메일 등 fire-and-forget 외부 호출용으로 상한이 있는 풀을 제공한다.
+ */
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "mailExecutor")
+    public ThreadPoolTaskExecutor mailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("mail-async-");
+        // 큐가 가득 차면 호출 스레드에서 직접 실행 — 작업 유실 방지
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(15);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/shelfeed/backend/global/config/CorsConfig.java
+++ b/src/main/java/com/shelfeed/backend/global/config/CorsConfig.java
@@ -7,21 +7,31 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
 public class CorsConfig {
 
+    // 콤마로 여러 오리진 허용 가능. 운영에서는 CORS_ALLOWED_ORIGIN 환경변수로 실제 프론트 도메인을 반드시 주입할 것
+    // (미주입 시 localhost 기본값으로 동작하므로 운영 배포 시 누락 금지).
     @Value("${cors.allowed-origin:http://localhost:5173}")
-    private String allowedOrigin;
+    private String allowedOrigins;
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(allowedOrigin));
+        // 콤마 구분 다중 오리진 지원 (공백 trim)
+        config.setAllowedOrigins(Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList());
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        config.setAllowedHeaders(List.of("*"));
+        // "*" 대신 실제 사용하는 요청 헤더만 화이트리스트 (credentials 허용 시 와일드카드 지양)
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
+        // 리프레시 토큰이 httpOnly 쿠키로 교차 오리진 전송되므로 credentials 허용은 유지해야 한다.
         config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/shelfeed/backend/global/config/WebConfig.java
+++ b/src/main/java/com/shelfeed/backend/global/config/WebConfig.java
@@ -3,9 +3,11 @@ package com.shelfeed.backend.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.util.List;
 
 @Configuration
@@ -13,7 +15,12 @@ public class WebConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        RestTemplate restTemplate = new RestTemplate();
+        // 외부 API(알라딘 등) 호출이 무한정 요청 스레드를 점유하지 않도록 connect/read 타임아웃 설정.
+        // (타임아웃 미설정 시 외부 의존성 지연이 Tomcat 스레드풀 고갈로 전파됨)
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(3));
+        factory.setReadTimeout(Duration.ofSeconds(10));
+        RestTemplate restTemplate = new RestTemplate(factory);
 
         // 알라딘 API는 Content-Type: text/javascript 로 JSON을 반환 → Jackson이 처리할 수 있도록 추가
         MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();

--- a/src/main/java/com/shelfeed/backend/global/email/EmailService.java
+++ b/src/main/java/com/shelfeed/backend/global/email/EmailService.java
@@ -1,6 +1,12 @@
 package com.shelfeed.backend.global.email;
 
 public interface EmailService {
+    // 동기 — 호출자가 발송 실패를 즉시 처리해야 하는 경로(예: 인증코드 재발송)에서 사용
     void sendVerificationEmail(String email, String code);
+
+    // 비동기 fire-and-forget — 회원가입 등 발송 지연이 요청 응답을 막으면 안 되는 경로에서 사용
+    void sendVerificationEmailAsync(String email, String code);
+
+    // 비동기 fire-and-forget — 비밀번호 재설정 메일(요청 응답과 분리)
     void sendPasswordResetEmail(String email, String token);
 }

--- a/src/main/java/com/shelfeed/backend/global/email/EmailServiceImpl.java
+++ b/src/main/java/com/shelfeed/backend/global/email/EmailServiceImpl.java
@@ -3,12 +3,15 @@ package com.shelfeed.backend.global.email;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
@@ -30,8 +33,25 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
+    @Async("mailExecutor")
+    public void sendVerificationEmailAsync(String email, String code) {
+        try {
+            send(email, "[Shelfeed] 이메일 인증 코드", buildVerificationBody(code));
+        } catch (EmailSendException e) {
+            log.warn("[EMAIL] 인증 이메일 비동기 발송 실패 — 재발송 API로 재시도 가능: {}",
+                    e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+        }
+    }
+
+    @Override
+    @Async("mailExecutor")
     public void sendPasswordResetEmail(String email, String token) {
-        send(email, "[Shelfeed] 비밀번호 재설정", buildPasswordResetBody(token));
+        try {
+            send(email, "[Shelfeed] 비밀번호 재설정", buildPasswordResetBody(token));
+        } catch (EmailSendException e) {
+            log.warn("[EMAIL] 비밀번호 재설정 이메일 비동기 발송 실패: {}",
+                    e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+        }
     }
 
     private void send(String to, String subject, String htmlBody) {

--- a/src/main/java/com/shelfeed/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/shelfeed/backend/global/jwt/JwtAuthenticationFilter.java
@@ -35,7 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(token)){
             try{
-                if (jwtProvider.validateToken(token) && !redisService.isBlacklisted(token)){// 인증된 토큰 and No 블랙
+                // validateToken(서명/만료) + access 타입 확인(refresh 토큰을 access로 사용 차단) + 블랙리스트 미등록
+                if (jwtProvider.validateToken(token) && jwtProvider.isAccessToken(token) && !redisService.isBlacklisted(token)){
                     Long memberUserId = jwtProvider.getMemberUserId(token); // 회원 번호 ID 꺼내기
                     UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(memberUserId)); //회원 찾기
 

--- a/src/main/java/com/shelfeed/backend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/shelfeed/backend/global/jwt/JwtProvider.java
@@ -16,6 +16,11 @@ import java.util.Date;
 @Component
 public class JwtProvider {
 
+    // 토큰 타입 클레임 — access 토큰과 refresh 토큰을 구분해 혼용(refresh를 access로 사용 등)을 차단한다.
+    private static final String CLAIM_TYPE = "type";
+    private static final String TYPE_ACCESS = "access";
+    private static final String TYPE_REFRESH = "refresh";
+
     private final SecretKey secretKey;
     private final long accessExpiration;
     private final long refreshExpiration;
@@ -35,6 +40,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .subject(String.valueOf(member.getMemberUserId()))
                 .claim("role", member.getRole().name())
+                .claim(CLAIM_TYPE, TYPE_ACCESS)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + accessExpiration))
                 .signWith(secretKey)
@@ -45,6 +51,7 @@ public class JwtProvider {
     public String generateRefreshToken(Member member) {
         return Jwts.builder()
                 .subject(String.valueOf(member.getMemberUserId()))
+                .claim(CLAIM_TYPE, TYPE_REFRESH)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
                 .signWith(secretKey)
@@ -66,6 +73,16 @@ public class JwtProvider {
     // 토큰에서 memberUserId 추출
     public Long getMemberUserId(String token) {
         return Long.parseLong(getClaims(token).getSubject());
+    }
+
+    // access 토큰 여부 — 인증 필터가 refresh 토큰을 Bearer access로 받는 것을 차단하는 데 사용
+    public boolean isAccessToken(String token) {
+        return TYPE_ACCESS.equals(getClaims(token).get(CLAIM_TYPE, String.class));
+    }
+
+    // refresh 토큰 여부 — 토큰 갱신 시 access 토큰을 refresh로 쓰는 것을 차단하는 데 사용
+    public boolean isRefreshToken(String token) {
+        return TYPE_REFRESH.equals(getClaims(token).get(CLAIM_TYPE, String.class));
     }
 
     // 토큰 남은 만료 시간 (ms) - 로그아웃 시 Redis 블랙리스트 TTL 용도

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: "optional:aws-parameterstore:/config/shelfeed/"
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,10 @@ spring:
       mail:
         smtp:
           auth: true
+          # SMTP 연결/응답/쓰기 타임아웃 — 메일 서버 지연이 요청 스레드를 무한 점유하는 것을 방지
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
           ssl:
             enable: ${MAIL_SSL_ENABLE:false}
             trust: ${MAIL_HOST:smtp.gmail.com}


### PR DESCRIPTION
## 개요

P0 등급 보안·안정성 이슈를 일괄 수정합니다.

closes #202

---

## 변경 사항

### 1. JWT 토큰 타입 클레임 분리 (보안)
- `JwtProvider`: access/refresh 토큰에 `type` 클레임 추가, 타입별 검증 메서드 분리
- `JwtAuthenticationFilter`: access 토큰만 인증에 사용하도록 토큰 혼용 차단
- `AuthService`: 재발급 엔드포인트에서 refresh 토큰 타입 검증 강제

### 2. CORS 강화 (보안)
- `CorsConfig`: 다중 오리진 지원, 허용 헤더 화이트리스트 명시, `maxAge` 캐시 설정

### 3. 외부 호출 타임아웃 (안정성)
- `WebConfig`: RestTemplate connect/read 타임아웃 설정
- `application.yml`: SMTP 타임아웃 추가

### 4. 이메일 전송 비동기화 (안정성)
- `EmailService` / `EmailServiceImpl`: `@Async` 적용으로 요청 스레드 블로킹 제거
- `AsyncConfig`: 바운디드 `mailExecutor` 스레드풀 추가

### 5. BookService 트랜잭션 분리 (안정성)
- `BookService`: 외부 HTTP 호출을 `@Transactional(NOT_SUPPORTED)`로 트랜잭션 밖 분리
- `BookPersistenceService` (신규): DB/ES 쓰기 책임 분리

### 6. AWS SSM Parameter Store 도입 (보안/운영)
- `build.gradle.kts`: AWS SSM SDK 의존성 추가
- `application-prod.yml`: 민감 설정 SSM 파라미터 참조로 외부화

### 7. 운영 문서 추가
- `docs/api-spec.md`: API 명세
- `docs/ssm-migration.md`: SSM 마이그레이션 가이드

---

## 테스트 체크리스트

- [ ] access 토큰으로 refresh 엔드포인트 호출 시 401 반환 확인
- [ ] refresh 토큰으로 인증 필터 통과 차단 확인
- [ ] 허용되지 않은 오리진 CORS 요청 차단 확인
- [ ] 이메일 전송이 비동기로 동작하며 요청 응답 블로킹 없음 확인
- [ ] BookService 외부 API 호출 중 DB 트랜잭션 미보유 확인
- [ ] 프로덕션 환경에서 SSM 파라미터 정상 로딩 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * REST API 명세서 공개 (64개 엔드포인트 문서화)

* **개선 사항**
  * 멀티 오리진 CORS 지원 확대
  * 외부 API 호출 시 타임아웃 설정으로 응답 무한 대기 방지
  * 이메일 발송 안정성 개선
  * 토큰 검증 강화로 보안 향상

* **문서**
  * AWS 파라미터 저장소 마이그레이션 가이드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->