### PR TITLE
fix: CORS 허용 오리진 기본값 누락 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,6 +38,12 @@ spring:
             class: javax.net.ssl.SSLSocketFactory
             fallback: false
 
+# CORS 허용 오리진 — CORS_ALLOWED_ORIGIN 환경변수가 있으면 우선 사용하고,
+# 미주입 시에도 운영 프론트 도메인(apex+www)으로 동작하도록 기본값을 명시한다.
+# (환경변수 누락 시 localhost로 떨어져 전 API가 차단되던 문제 방지. 콤마 구분 다중 오리진.)
+cors:
+  allowed-origin: ${CORS_ALLOWED_ORIGIN:https://shelfeed.co.kr,https://www.shelfeed.co.kr}
+
 # 운영 환경엔 Tempo/Zipkin 인프라가 없으므로 트레이싱 비활성화 (로그 폭주 방지)
 management:
   tracing:


### PR DESCRIPTION
## 문제

`application-prod.yml`에 `cors.allowed-origin` 키가 없어, `CORS_ALLOWED_ORIGIN` 환경변수가 미주입된 경우 스프링 바인딩이 `localhost` 기본값으로 폴백됐다. 이로 인해 운영 환경에서 전 API가 CORS 차단되는 장애가 발생했다.

## 변경 내용

- `src/main/resources/application-prod.yml`에 `cors.allowed-origin` 항목 추가
- 환경변수 `CORS_ALLOWED_ORIGIN` 우선 사용, 미주입 시 운영 도메인(`https://shelfeed.co.kr`, `https://www.shelfeed.co.kr`)으로 fallback

## 검증

- 환경변수 있을 때: 환경변수 값 사용 (기존 동작 유지)
- 환경변수 없을 때: `https://shelfeed.co.kr,https://www.shelfeed.co.kr` 적용 → CORS 차단 해소

closes #204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 운영 환경에서 CORS 설정을 개선했습니다. 환경변수를 통한 유연한 도메인 관리가 가능해지며, 기본값으로 서비스 공식 도메인이 자동 설정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->