### PR TITLE
[Fix] 통합검색 type=all 커서 분리 — bookCursor / userCursor 파라미터 추가

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/search/controller/SearchController.java
+++ b/src/main/java/com/shelfeed/backend/domain/search/controller/SearchController.java
@@ -16,15 +16,20 @@ public class SearchController {
     private final SearchService searchService;
 
     // 10.1 통합 검색  GET /api/v1/search
+    // cursor: 단일 타입(type=book/user) 검색용 하위호환 파라미터.
+    // bookCursor/userCursor: type=all에서 books·users를 독립적으로 페이징하기 위한 분리 커서.
+    // (books 커서=bookId, users 커서=memberUserId로 ID 공간이 달라 단일 cursor 공유 시 페이징이 어긋남)
     @GetMapping
     public ApiResponse<SearchResponse> search(
             @RequestParam String query,
             @RequestParam(defaultValue = "all") String type,
             @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Long bookCursor,
+            @RequestParam(required = false) Long userCursor,
             @RequestParam(defaultValue = "20") int limit,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long memberUserId = userDetails != null ? userDetails.getMember().getMemberUserId() : null;
         return ApiResponse.success(200,
-                searchService.search(query, type, cursor, limit, memberUserId));
+                searchService.search(query, type, cursor, bookCursor, userCursor, limit, memberUserId));
     }
 }

--- a/src/main/java/com/shelfeed/backend/domain/search/service/SearchService.java
+++ b/src/main/java/com/shelfeed/backend/domain/search/service/SearchService.java
@@ -60,7 +60,7 @@ public class SearchService {
 
     //통합 검색
     @Transactional
-    public SearchResponse search (String query, String type, Long cursor, int limit, Long memberUserId){
+    public SearchResponse search (String query, String type, Long cursor, Long bookCursor, Long userCursor, int limit, Long memberUserId){
         Span span = tracer.nextSpan().name("search").start();
         try (Tracer.SpanInScope ws = tracer.withSpan(span)) {
         //쿼리 여부 확인
@@ -88,8 +88,13 @@ public class SearchService {
         SearchPageResponse<BookSearchResult> books = SearchPageResponse.empty();
         SearchPageResponse<UserSearchResult> users = SearchPageResponse.empty();
 
-        if (type.equals("all") || type.equals("book")) { books = searchBooks(query, cursor, limit); }
-        if (type.equals("all") || type.equals("user")) { users = searchUsers(query, cursor, limit, memberUserId); }
+        // books 커서(bookId)와 users 커서(memberUserId)는 ID 공간이 다르므로 독립 커서로 페이징한다.
+        // type=all에선 bookCursor/userCursor를 각각 사용하고, 단일 타입 검색은 하위호환으로 cursor를 폴백한다.
+        Long effectiveBookCursor = bookCursor != null ? bookCursor : cursor;
+        Long effectiveUserCursor = userCursor != null ? userCursor : cursor;
+
+        if (type.equals("all") || type.equals("book")) { books = searchBooks(query, effectiveBookCursor, limit); }
+        if (type.equals("all") || type.equals("user")) { users = searchUsers(query, effectiveUserCursor, limit, memberUserId); }
 
         return SearchResponse.builder()
                 .books(books)


### PR DESCRIPTION
## 개요

통합검색(`type=all`)에서 책·유저가 단일 `cursor` 값을 공유해 페이징이 어긋나던 문제를 수정합니다.

closes #208

## 변경 사항

- `SearchController`: 통합검색 엔드포인트에 `bookCursor`, `userCursor` (optional Long) 파라미터 추가. 기존 `cursor`는 `type=book`/`type=user` 단일 타입 검색의 하위호환용으로 유지.
- `SearchService`: `search` 시그니처에 두 커서 추가. `effectiveBookCursor = bookCursor != null ? bookCursor : cursor`, `effectiveUserCursor = userCursor != null ? userCursor : cursor` 로 계산 후 `searchBooks` / `searchUsers` 에 독립 전달.

## 원인 및 해결

`type=all` 페이징 시 책(bookId 기준)과 유저(memberUserId 기준)가 서로 다른 ID 공간을 갖지만 하나의 `cursor` 값을 공유했기 때문에 한쪽 결과가 누락되거나 중복되는 버그가 발생했습니다. 커서를 분리해 각 도메인이 독립적으로 페이징하도록 수정합니다.

## 하위호환

`type=book` / `type=user` 요청은 기존 `cursor` 파라미터 그대로 동작합니다.

## 참고

프론트엔드(1-D FE) 대응은 배포 후 별도 PR에서 진행합니다.

## 체크리스트

- [x] `./gradlew compileJava` EXIT 0 확인
- [x] 기존 `cursor` 하위호환 유지 확인
- [x] SearchController 호출처 업데이트 확인