### PR TITLE
fix: 통합검색 ES 색인 드리프트 자가치유 및 테스트 복구

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/book/service/BookPersistenceService.java
+++ b/src/main/java/com/shelfeed/backend/domain/book/service/BookPersistenceService.java
@@ -59,13 +59,11 @@ public class BookPersistenceService {
                 .toList();
 
         Map<String, Book> all = new HashMap<>(existing);
-        List<Book> toIndex = new ArrayList<>();
         if (!newBooks.isEmpty()) {
             try {
                 // saveAllAndFlush로 즉시 flush — try 블록 내에서 unique 위반 발생하도록
                 bookRepository.saveAllAndFlush(newBooks);
                 newBooks.forEach(b -> all.put(b.getIsbn13(), b));
-                toIndex.addAll(newBooks);
             } catch (DataIntegrityViolationException e) {
                 // 동시 요청으로 인한 unique 위반 — Session에 null ID 엔티티가 남아있으므로
                 // clear() 후 재조회해야 AssertionFailure를 방지할 수 있다.
@@ -73,10 +71,13 @@ public class BookPersistenceService {
                 entityManager.clear();
                 List<Book> refetched = bookRepository.findByIsbn13In(isbns);
                 refetched.forEach(b -> all.put(b.getIsbn13(), b));
-                toIndex.addAll(refetched); // 멱등 — 이미 색인된 책도 동일 ID로 덮어쓰기
             }
         }
-        // ES 색인은 트랜잭션 외부 효과 — DB 저장 성공 후 best-effort 색인 (성공 여부 반환)
+        // [Fix A] 신규/기존 가리지 않고 이번 검색의 알라딘 결과 전체를 멱등 재색인한다.
+        // 신규 도서만 색인하면 "DB엔 있는데 ES엔 없는" 책(시드 데이터·과거 색인 실패분 등)이
+        // 통합검색에서 영영 안 잡힌다. 전체 재색인(동일 ID 덮어쓰기)으로 DB↔ES 드리프트를 자가치유한다.
+        // 재색인량은 검색 limit 크기로 바운드되어 부담이 작다.
+        List<Book> toIndex = new ArrayList<>(all.values());
         boolean indexed = indexToElasticsearch(toIndex);
         return new UpsertResult(all, indexed);
     }

--- a/src/test/java/com/shelfeed/backend/domain/book/BookServiceTest.java
+++ b/src/test/java/com/shelfeed/backend/domain/book/BookServiceTest.java
@@ -10,6 +10,7 @@ import com.shelfeed.backend.domain.book.dto.response.BookReviewListResponse;
 import com.shelfeed.backend.domain.book.dto.response.BookSearchListResponse;
 import com.shelfeed.backend.domain.book.entity.Book;
 import com.shelfeed.backend.domain.book.repository.BookRepository;
+import com.shelfeed.backend.domain.book.service.BookPersistenceService;
 import com.shelfeed.backend.domain.book.service.BookService;
 import com.shelfeed.backend.domain.library.entity.LibraryBook;
 import com.shelfeed.backend.domain.library.enums.ReadingStatus;
@@ -33,6 +34,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -50,6 +52,8 @@ class BookServiceTest {
     @Mock ReviewRepository reviewRepository;
     @Mock ReviewLikeRepository reviewLikeRepository;
     @Mock AladinClient aladinApiClient;
+    // #203 리팩터로 DB upsert/ES 색인이 BookPersistenceService로 분리됨 — BookService가 위임함
+    @Mock BookPersistenceService bookPersistenceService;
 
     @InjectMocks BookService bookService;
 
@@ -112,7 +116,8 @@ class BookServiceTest {
             request.setLimit(10);
 
             given(aladinApiClient.search("test", 1, 11)).willReturn(aladinResponse);
-            given(bookRepository.findByIsbn13In(List.of("9781234567890"))).willReturn(List.of(book));
+            given(bookPersistenceService.upsertAndGetBooks(anyList()))
+                    .willReturn(new BookPersistenceService.UpsertResult(Map.of("9781234567890", book), true));
             given(memberRepository.findByMemberUserId(1L)).willReturn(Optional.of(member));
             given(libraryRepository.findBookIdsByMemberAndBookIdIn(eq(member), anyList())).willReturn(Set.of(10L));
 
@@ -149,7 +154,8 @@ class BookServiceTest {
             request.setLimit(10);
 
             given(aladinApiClient.search("test", 1, 11)).willReturn(aladinResponse);
-            given(bookRepository.findByIsbn13In(List.of("9781234567890"))).willReturn(List.of(book));
+            given(bookPersistenceService.upsertAndGetBooks(anyList()))
+                    .willReturn(new BookPersistenceService.UpsertResult(Map.of("9781234567890", book), true));
 
             BookSearchListResponse response = bookService.searchBooks(request, null);
 
@@ -249,12 +255,12 @@ class BookServiceTest {
 
             given(bookRepository.findByIsbn13("9781234567890")).willReturn(Optional.empty());
             given(aladinApiClient.lookupByIsbn("9781234567890")).willReturn(aladinResponse);
-            given(bookRepository.save(any(Book.class))).willReturn(book);
+            given(bookPersistenceService.findOrCreateBook(any())).willReturn(book);
 
             BookDetailResponse response = bookService.getBookByIsbn("9781234567890", null);
 
             assertThat(response).isNotNull();
-            then(bookRepository).should().save(any(Book.class));
+            then(bookPersistenceService).should().findOrCreateBook(any());
         }
 
         @Test


### PR DESCRIPTION
## 개요

통합검색 첫 검색 시 도서 결과가 0건으로 반환되는 문제(ES 색인 드리프트)를 수정하고, 관련 테스트 3개를 복구한다.

closes #210

## 변경 내용

### BookPersistenceService.java
- `upsertAndGetBooks`의 ES 색인 대상을 신규 도서(`newBooks`)에서 이번 알라딘 검색 결과 전체(`all.values()`)로 변경
- 기존: 신규 도서만 색인 → "DB엔 있는데 ES엔 없는" 책(시드 데이터·과거 색인 실패분)이 통합검색에서 누락
- 변경: 동일 ID로 멱등 재색인 → 검색마다 DB↔ES 드리프트 자가치유. 재색인량은 검색 limit 크기로 바운드

### BookServiceTest.java
- `#203` 리팩터 이후 누락됐던 `BookPersistenceService` mock 추가
- `upsertAndGetBooks` / `findOrCreateBook` 위임 호출을 stub으로 갱신
- 불필요해진 `findByIsbn13In` / `save` stub 제거
- 기존 3개 실패 테스트 복구

## 검증

- `./gradlew compileJava` → EXIT 0
- `./gradlew test --tests BookServiceTest` → 15/15 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 통합검색 색인 범위를 확대하여 데이터베이스에는 존재하지만 검색 서비스에서 누락된 도서들이 정상적으로 조회되도록 개선했습니다.

* **테스트**
  * 도서 저장 로직 관련 테스트 케이스를 최신 구조에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->