### PR TITLE
fix: 댓글 좋아요 차단 관계 검증 및 알림 설정 조건 적용 (#216)

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/shelfeed/backend/domain/comment/service/CommentService.java
@@ -183,16 +183,25 @@ public class CommentService {
         if (!comment.getReview().getReviewId().equals(reviewId)) {
             throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND);
         }
-        if (comment.getMember().getMemberUserId().equals(memberUserId)) {
+        Member commentOwner = comment.getMember();
+        if (commentOwner.getMemberUserId().equals(memberUserId)) {
             throw new BusinessException(ErrorCode.SELF_LIKE_NOT_ALLOWED);
+        }
+        // 차단 관계 확인 (양방향) — 감상 좋아요와 동일하게 차단 시 좋아요 자체를 막는다
+        if (blockRepository.existsByBlockerAndBlocked(commentOwner, member) ||
+            blockRepository.existsByBlockerAndBlocked(member, commentOwner)) {
+            throw new BusinessException(ErrorCode.BLOCKED_USER);
         }
         if (commentLikeRepository.existsByComment_CommentIdAndMember_MemberUserId(commentId, memberUserId)){
             throw new BusinessException(ErrorCode.ALREADY_COMMENT_LIKED);
         }
         commentLikeRepository.save(CommentLike.create(member, comment));
-        notificationRepository.save(Notification.createCommentNotification(
-                comment.getMember(), member, NotificationType.COMMENT_LIKE, reviewId, comment.getCommentId()));
         commentRepository.increaseLikeCount(comment.getCommentId());
+        // 수신자가 좋아요 알림을 켠 경우에만 발송 (감상 좋아요와 동일 정책)
+        if (commentOwner.getNotificationPreferences().isLikeEnabled()) {
+            notificationRepository.save(Notification.createCommentNotification(
+                    commentOwner, member, NotificationType.COMMENT_LIKE, reviewId, comment.getCommentId()));
+        }
         return CommentLikeResponse.of(getComment(commentId));
     }
 


### PR DESCRIPTION
## 개요

closes #216

댓글 좋아요(`likeComment`)에 감상 좋아요(`likeReview`)와 동일한 정합성 정책을 적용합니다.

## 변경 내용

- 양방향 차단 관계(차단하거나 차단당한 경우) 시 `BLOCKED_USER` 예외로 좋아요 자체를 차단
- 수신자의 `NotificationPreferences.isLikeEnabled()`가 `true`일 때만 `COMMENT_LIKE` 알림 발송
- `comment.getMember()`를 `commentOwner` 지역변수로 추출하여 가독성 개선

## 테스트

- [x] `./gradlew compileJava` 성공
- [x] `CommentService.java` 단일 파일 변경만 포함 확인