### PR TITLE
fix: 좋아요/팔로우/서재추가 동시 요청 경쟁 조건 멱등 처리

### DIFF
--- a/src/main/java/com/shelfeed/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/shelfeed/backend/domain/comment/service/CommentService.java
@@ -20,6 +20,7 @@ import com.shelfeed.backend.global.common.exception.BusinessException;
 import com.shelfeed.backend.global.common.exception.ErrorCode;
 import com.shelfeed.backend.global.common.helper.MemberLoader;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -195,7 +196,12 @@ public class CommentService {
         if (commentLikeRepository.existsByComment_CommentIdAndMember_MemberUserId(commentId, memberUserId)){
             throw new BusinessException(ErrorCode.ALREADY_COMMENT_LIKED);
         }
-        commentLikeRepository.save(CommentLike.create(member, comment));
+        // 동시 요청 경쟁: exists 동시 통과 후 unique 위반을 409로 멱등 변환 (saveAndFlush로 즉시 검출)
+        try {
+            commentLikeRepository.saveAndFlush(CommentLike.create(member, comment));
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.ALREADY_COMMENT_LIKED);
+        }
         commentRepository.increaseLikeCount(comment.getCommentId());
         // 수신자가 좋아요 알림을 켠 경우에만 발송 (감상 좋아요와 동일 정책)
         if (commentOwner.getNotificationPreferences().isLikeEnabled()) {

--- a/src/main/java/com/shelfeed/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/com/shelfeed/backend/domain/follow/service/FollowService.java
@@ -21,6 +21,7 @@ import com.shelfeed.backend.global.common.exception.BusinessException;
 import com.shelfeed.backend.global.common.exception.ErrorCode;
 import com.shelfeed.backend.global.common.helper.MemberLoader;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,7 +66,13 @@ public class FollowService {
             throw new BusinessException(ErrorCode.ALREADY_FOLLOWING);
         }
 
-        Follow follow = followRepository.save(Follow.create(follower,followee));
+        // 동시 요청 경쟁: exists 동시 통과 후 unique 위반을 409로 멱등 변환 (saveAndFlush로 즉시 검출)
+        Follow follow;
+        try {
+            follow = followRepository.saveAndFlush(Follow.create(follower, followee));
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.ALREADY_FOLLOWING);
+        }
         // 카운트 업데이트
         memberRepository.increaseFollowingCount(follower.getMemberUserId());
         memberRepository.increaseFollowerCount(followee.getMemberUserId());

--- a/src/main/java/com/shelfeed/backend/domain/library/service/LibraryService.java
+++ b/src/main/java/com/shelfeed/backend/domain/library/service/LibraryService.java
@@ -17,6 +17,7 @@ import com.shelfeed.backend.global.common.exception.BusinessException;
 import com.shelfeed.backend.global.common.exception.ErrorCode;
 import com.shelfeed.backend.global.common.helper.MemberLoader;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +44,12 @@ public class LibraryService {
             throw new BusinessException(ErrorCode.ALREADY_IN_LIBRARY);
         }
         LibraryBook libraryBook = LibraryBook.create(member, book, request.getStatus());
-        libraryRepository.save(libraryBook);
+        // 동시 요청 경쟁: exists 동시 통과 후 unique 위반을 409로 멱등 변환 (saveAndFlush로 즉시 검출)
+        try {
+            libraryRepository.saveAndFlush(libraryBook);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.ALREADY_IN_LIBRARY);
+        }
         return LibraryBookAddResponse.of(libraryBook);
     }
 

--- a/src/main/java/com/shelfeed/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/shelfeed/backend/domain/review/service/ReviewService.java
@@ -31,6 +31,7 @@ import com.shelfeed.backend.domain.tag.entity.Tag;
 import com.shelfeed.backend.global.common.exception.BusinessException;
 import com.shelfeed.backend.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -234,7 +235,13 @@ public class ReviewService {
         if (reviewLikeRepository.existsByReview_ReviewIdAndMember_MemberUserId(reviewId,memberUserId)){
             throw new BusinessException(ErrorCode.ALREADY_REVIEW_LIKED);
         }
-        reviewLikeRepository.save(ReviewLike.create(review,member));// 저장
+        // saveAndFlush로 INSERT를 즉시 실행해 동시 요청 경쟁(exists 동시 통과)에서 unique 위반을
+        // 이 지점에서 잡는다. 미적용 시 커밋 시점에 터져 500으로 노출됨 → 409로 멱등 변환.
+        try {
+            reviewLikeRepository.saveAndFlush(ReviewLike.create(review, member));
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.ALREADY_REVIEW_LIKED);
+        }
         reviewRepository.increaseLikeCount(review.getReviewId());
         if (review.getMember().getNotificationPreferences().isLikeEnabled()) {
             notificationRepository.save(Notification.createUserNotification(


### PR DESCRIPTION
## 개요

좋아요/팔로우/서재추가에서 "exists 체크 후 save" 패턴이 동시 요청 경쟁 상황에서 unique 제약 위반(500)을 노출하던 문제를 수정합니다.

closes #218

## 변경 내용

`save()` → `saveAndFlush()`로 변경하고 `DataIntegrityViolationException`을 캐치하여 해당 `ALREADY_*` BusinessException(409)으로 멱등 변환합니다. 기존 `exists` 빠른경로는 그대로 유지합니다.

| 서비스 | 메서드 | 예외 |
|---|---|---|
| ReviewService | likeReview | ALREADY_REVIEW_LIKED |
| CommentService | likeComment | ALREADY_COMMENT_LIKED |
| FollowService | follow | ALREADY_FOLLOWING |
| LibraryService | addBook | ALREADY_IN_LIBRARY |

## 체크리스트

- [x] `./gradlew compileJava` 통과
- [x] 본 변경으로 인한 신규 회귀 없음
- [x] 동시 요청 시 500 대신 409 반환 확인